### PR TITLE
Add links to Google Sheets documentation to the README.md

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,25 @@
+default: true
+
+# Unordered list indentation
+MD007: { indent: 2 }
+
+# Line length
+MD013: { line_length: 90, tables: false, code_blocks: false }
+
+# Heading duplication is allowed for non-sibling headings
+MD024: { siblings_only: true }
+
+# Do not allow the specified trailig punctuation in a header
+MD026: { punctuation: '.,;:' }
+
+# Order list items must have a prefix that increases in numerical order
+MD029: { style: 'ordered' }
+
+# Lists do not need to be surrounded by blank lines
+MD032: false
+
+# Allow raw HTML in Markdown
+MD033: false
+
+# Allow emphasis to be used instead of a heading
+MD036: false

--- a/README.md
+++ b/README.md
@@ -9,12 +9,32 @@
 
 Unofficial helpers for the Google Sheets V4 API
 
-- [SheetsV4](#sheetsv4)
-  - [Installation](#installation)
-  - [Usage](#usage)
-  - [Development](#development)
-  - [Contributing](#contributing)
-  - [License](#license)
+* [Important Links for Programming Google Sheets](#important-links-for-programming-google-sheets)
+  * [General API Documentation](#general-api-documentation)
+  * [Ruby Implementation of the Sheets API](#ruby-implementation-of-the-sheets-api)
+  * [Other Links](#other-links)
+* [Installation](#installation)
+* [Usage](#usage)
+* [Development](#development)
+* [Contributing](#contributing)
+* [License](#license)
+
+## Important Links for Programming Google Sheets
+
+### General API Documentation
+
+* [Google Sheets API Overview](https://developers.google.com/sheets/api/guides/concepts)
+* [Google Sheets API Reference](https://developers.google.com/sheets/api/reference/rest)
+* [Batch Update Requests](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request)
+
+### Ruby Implementation of the Sheets API
+
+* [SheetsService Class](https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-sheets_v4/lib/google/apis/sheets_v4/service.rb)
+* [All Other Sheets Classes](https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-sheets_v4/lib/google/apis/sheets_v4/classes.rb)
+
+### Other Links
+
+* [Apps Script for Sheets](https://developers.google.com/apps-script/guides/sheets)
 
 ## Installation
 


### PR DESCRIPTION
Add links that are useful when programming Google Sheets. This includes links in the following categories:

* General API Documentation
* Ruby Implementation of the Sheets API
* Other Links