### PR TITLE
Add SheetsV4.validate_api_object

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ desc 'Run the same tasks that the CI build will run'
 if RUBY_PLATFORM == 'java'
   task default: %w[spec rubocop bundle:audit build]
 else
-  task default: %w[spec rubocop yard yard:audit yard:coverage bundle:audit build]
+  task default: %w[spec rubocop yard bundle:audit build]
 end
 
 # Bundler Audit
@@ -58,28 +58,41 @@ end
 CLEAN << 'rubocop-report.json'
 
 unless RUBY_PLATFORM == 'java'
-  # YARD
+  # yard:build
 
   require 'yard'
-  YARD::Rake::YardocTask.new do |t|
-    t.files = %w[lib/**/*.rb examples/**/*]
+
+  YARD::Rake::YardocTask.new('yard:build') do |t|
+    t.files = %w[lib/**/*.rb]
+    t.stats_options = ['--list-undoc']
   end
 
   CLEAN << '.yardoc'
   CLEAN << 'doc'
 
-  # Yardstick
+  # yard:audit
 
   desc 'Run yardstick to show missing YARD doc elements'
   task :'yard:audit' do
     sh "yardstick 'lib/**/*.rb'"
   end
 
-  # Yardstick coverage
+  # yard:coverage
 
   require 'yardstick/rake/verify'
 
   Yardstick::Rake::Verify.new(:'yard:coverage') do |verify|
     verify.threshold = 100
+    verify.require_exact_threshold = false
+  end
+
+  task yard: %i[yard:build yard:audit yard:coverage]
+
+  # github-pages:publish
+
+  require 'github_pages_rake_tasks'
+  GithubPagesRakeTasks::PublishTask.new do |task|
+    # task.doc_dir = 'documentation'
+    task.verbose = true
   end
 end

--- a/lib/sheets_v4.rb
+++ b/lib/sheets_v4.rb
@@ -1,8 +1,76 @@
 # frozen_string_literal: true
 
 require_relative 'sheets_v4/version'
+require_relative 'sheets_v4/validate_api_object'
 
+require 'json'
+require 'logger'
+require 'net/http'
+
+# Unofficial helpers for the Google Sheets V4 API
+#
+# @api public
+#
 module SheetsV4
-  class Error < StandardError; end
-  # Your code goes here...
+  # Validate the object using the named JSON schema
+  #
+  # The JSON schemas are loaded from the Google Disocvery API. The schemas names are
+  # returned by `SheetsV4.api_object_schemas.keys`.
+  #
+  # @example
+  #   schema_name = 'BatchUpdateSpreadsheetRequest'
+  #   object = { 'requests' => [] }
+  #   SheetsV4.validate_api_object(schema_name:, object:)
+  #
+  # @param schema_name [String] the name of the schema to validate against
+  # @param object [Object] the object to validate
+  # @param logger [Logger] the logger to use for logging error, info, and debug message
+  #
+  # @raise [RuntimeError] if the object does not conform to the schema
+  #
+  # @return [void]
+  #
+  def self.validate_api_object(schema_name:, object:, logger: Logger.new(nil))
+    ValidateApiObject.new(logger).call(schema_name, object)
+  end
+
+  # A hash of schemas keyed by the schema name loaded from the Google Discovery API
+  #
+  # @example
+  #   SheetsV4.api_object_schemas #=> { 'PersonSchema' => { 'type' => 'object', ... } ... }
+  #
+  # @return [Hash<String, Object>] a hash of schemas keyed by schema name
+  #
+  def self.api_object_schemas
+    schema_load_semaphore.synchronize { @api_object_schemas ||= load_api_object_schemas }
+  end
+
+  # Validate
+  # A mutex used to synchronize access to the schemas so they are only loaded
+  # once.
+  #
+  @schema_load_semaphore = Thread::Mutex.new
+
+  # A mutex used to synchronize access to the schemas so they are only loaded once
+  #
+  # @return [Thread::Mutex]
+  #
+  # @api private
+  #
+  def self.schema_load_semaphore = @schema_load_semaphore
+
+  # Load the schemas from the Google Discovery API
+  #
+  # @return [Hash<String, Object>] a hash of schemas keyed by schema name
+  #
+  # @api private
+  #
+  def self.load_api_object_schemas
+    source = 'https://sheets.googleapis.com/$discovery/rest?version=v4'
+    resp = Net::HTTP.get_response(URI.parse(source))
+    data = resp.body
+    JSON.parse(data)['schemas'].tap do |schemas|
+      schemas.each { |_name, schema| schema['unevaluatedProperties'] = false }
+    end
+  end
 end

--- a/lib/sheets_v4/validate_api_object.rb
+++ b/lib/sheets_v4/validate_api_object.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'json_schemer'
+
+module SheetsV4
+  # Validate objects against a Google Sheets API request object schema
+  #
+  # @api public
+  #
+  class ValidateApiObject
+    # Create a new validator
+    #
+    # By default, a nil logger is used. This means that no messages are logged.
+    #
+    # @example
+    #   logger = Logger.new(STDOUT, :level => Logger::INFO)
+    #   validator = SheetsV4::ValidateApiObject.new(logger)
+    #
+    # @param logger [Logger] the logger to use
+    #
+    def initialize(logger = Logger.new(nil))
+      @logger = logger
+    end
+
+    # The logger to use internally
+    #
+    # Validation errors are logged at the error level. Other messages are logged
+    # at the debug level.
+    #
+    # @example
+    #   logger = Logger.new(STDOUT, :level => Logger::INFO)
+    #   validator = SheetsV4::ValidateApiObject.new(logger)
+    #   validator.logger == logger # => true
+    #   validator.logger.debug { "Debug message" }
+    #
+    # @return [Logger]
+    #
+    attr_reader :logger
+
+    # Validate the object using the JSON schema named schema_name
+    #
+    # @example
+    #   schema_name = 'BatchUpdateSpreadsheetRequest'
+    #   object = { 'requests' => [] }
+    #   validator = SheetsV4::ValidateApiObject.new
+    #   validator.call(schema_name, object)
+    #
+    # @param schema_name [String] the name of the schema to validate against
+    # @param object [Object] the object to validate
+    #
+    # @raise [RuntimeError] if the object does not conform to the schema
+    #
+    # @return [void]
+    #
+    def call(schema_name, object)
+      logger.debug { "Validating #{object} against #{schema_name}" }
+
+      schema = { '$ref' => schema_name }
+      schemer = JSONSchemer.schema(schema, ref_resolver:)
+      errors = schemer.validate(object)
+      raise_error!(schema_name, object, errors) if errors.any?
+
+      logger.debug { "Object #{object} conforms to #{schema_name}" }
+    end
+
+    private
+
+    # The resolver to use to resolve JSON schema references
+    # @return [SchemaRefResolver]
+    # @api private
+    def ref_resolver = @ref_resolver ||= SchemaRefResolver.new(logger)
+
+    # Raise an error when the object does not conform to the schema
+    # @return [void]
+    # @raise [RuntimeError]
+    # @api private
+    def raise_error!(schema_name, object, errors)
+      error = errors.first['error']
+      error_message = "Object #{object} does not conform to #{schema_name}: #{error}"
+      logger.error(error_message)
+      raise error_message
+    end
+  end
+
+  # Resolve JSON schema references to Google Sheets API schemas
+  #
+  # Uses the Google Discovery API to get the schemas. This is an implementation
+  # detail used to interact with JSONSchemer.
+  #
+  # @api private
+  #
+  class SchemaRefResolver
+    # Create a new schema resolver
+    #
+    # @param logger [Logger] the logger to use
+    #
+    # @api private
+    #
+    def initialize(logger)
+      @logger = logger
+    end
+
+    # The logger to use internally
+    #
+    # Currently, only info messages are logged.
+    #
+    # @return [Logger]
+    #
+    # @api private
+    #
+    attr_reader :logger
+
+    # Resolve a JSON schema reference
+    #
+    # @param ref [String] the reference to resolve usually in the form "#/definitions/schema_name"
+    #
+    # @return [Hash] the schema object as a hash
+    #
+    # @api private
+    #
+    def call(ref)
+      schema_name = ref.path[1..]
+      logger.debug { "Reading schema #{schema_name}" }
+      schema_object = SheetsV4.api_object_schemas[schema_name]
+      raise "Schema for #{ref} not found" unless schema_object
+
+      schema_object.to_h.tap do |schema|
+        schema['unevaluatedProperties'] = false
+      end
+    end
+  end
+end

--- a/lib/sheets_v4/version.rb
+++ b/lib/sheets_v4/version.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
 module SheetsV4
+  # The version of this gem
   VERSION = '0.1.1'
 end

--- a/sheets_v4.gemspec
+++ b/sheets_v4.gemspec
@@ -48,7 +48,9 @@ Gem::Specification.new do |spec|
   end
 
   spec.add_runtime_dependency 'activesupport', '~> 7.0'
+  spec.add_development_dependency 'github_pages_rake_tasks', '~> 0.1'
   spec.add_runtime_dependency 'google-apis-sheets_v4', '~> 0.26'
   spec.add_runtime_dependency 'googleauth'
+  spec.add_runtime_dependency 'json_schemer', '~> 2.0'
   spec.add_runtime_dependency 'rltk', '~> 3.0'
 end

--- a/spec/sheets_v4_spec.rb
+++ b/spec/sheets_v4_spec.rb
@@ -1,7 +1,76 @@
 # frozen_string_literal: true
 
+require 'logger'
+require 'net/http'
+
 RSpec.describe SheetsV4 do
   it 'has a version number' do
     expect(SheetsV4::VERSION).not_to be nil
+  end
+
+  let(:schemas) do
+    {
+      'PersonSchema' => {
+        'type' => 'object',
+        'properties' => {
+          'name' => { 'type' => 'string' },
+          'location' => { '$ref' => 'LocationSchema' },
+          'active' => { 'type' => 'boolean' }
+        }
+      },
+      'LocationSchema' => {
+        'type' => 'object',
+        'properties' => {
+          'city' => { 'type' => 'string' },
+          'state' => { 'type' => 'string' }
+        }
+      }
+    }
+  end
+  let(:sheets_discovery_uri) { URI.parse('https://sheets.googleapis.com/$discovery/rest?version=v4') }
+  let(:sheets_discovery_document) { double('sheets_discovery_document', body: JSON.generate('schemas' => schemas)) }
+  before do
+    allow(Net::HTTP).to(
+      receive(:get_response)
+      .with(sheets_discovery_uri)
+      .and_return(sheets_discovery_document)
+    )
+  end
+
+  describe '.validate_api_object' do
+    subject { described_class.validate_api_object(schema_name:, object:, logger:) }
+    let(:schema_name) { 'PersonSchema' }
+    let(:object) do
+      { 'name' => 'James', 'location' => { 'city' => 'Temecula', 'state' => 'CA' }, 'active' => true }
+    end
+
+    let(:logger) { Logger.new(nil) }
+
+    it 'validates the object against the schema' do
+      expect { subject }.not_to raise_error
+    end
+
+    context 'with an object that does not conform to the schema' do
+      let(:object) { { 'name' => 'James', 'banned' => false } }
+      it 'should raise an error if the object is not valid' do
+        expect { subject }.to raise_error(RuntimeError, /does not conform/)
+      end
+    end
+  end
+
+  describe '.self.api_object_schemas' do
+    it 'should return the schemas from the Google Discovery API for Sheets V4' do
+      expect(described_class.api_object_schemas).to have_attributes(keys: %w[PersonSchema LocationSchema])
+    end
+
+    it 'should return the PersonSchema adding the unevaluatedProperties=false property' do
+      expected_schema = schemas['PersonSchema'].merge('unevaluatedProperties' => false)
+      expect(described_class.api_object_schemas['PersonSchema']).to eq(expected_schema)
+    end
+
+    it 'should return the LocationSchema adding the unevaluatedProperties=false property' do
+      expected_schema = schemas['LocationSchema'].merge('unevaluatedProperties' => false)
+      expect(described_class.api_object_schemas['LocationSchema']).to eq(expected_schema)
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,47 @@ require 'json'
 
 SimpleCov.formatters = [SimpleCov::Formatter::HTMLFormatter, SimpleCov::Formatter::LcovFormatter]
 
+# Return `true` if the environment variable is set to a truthy value
+#
+# @example
+#   env_true?('COV_SHOW_UNCOVERED')
+#
+# @param name [String] the name of the environment variable
+# @return [Boolean]
+#
+def env_true?(name)
+  value = ENV.fetch(name, '').downcase
+  %w[yes on true 1].include?(value)
+end
+
+# Return `true` if the environment variable is NOT set to a truthy value
+#
+# @example
+#   env_false?('COV_NO_FAIL')
+#
+# @param name [String] the name of the environment variable
+# @return [Boolean]
+#
+def env_false?(name)
+  !env_true?(name)
+end
+
+# Return `true` if the the test run should fail if the coverage is below the threshold
+#
+# @return [Boolean]
+#
+def fail_on_low_coverage?
+  !(RSpec.configuration.dry_run? || env_true?('COV_NO_FAIL'))
+end
+
+# Return `true` if the the test run should show the lines not covered by tests
+#
+# @return [Boolean]
+#
+def show_lines_not_covered?
+  env_true?('COV_SHOW_UNCOVERED')
+end
+
 # Report if the test coverage was below the configured threshold
 #
 # The threshold is configured by setting the `test_coverage_threshold` variable


### PR DESCRIPTION
This PR adds the following methods:

## validate_api_object

`SheetsV4.validate_api_object(schema_name:, object:, logger:)`

Validate the object using the named JSON schema

The JSON schemas are loaded from the Google Disocvery API. The schemas names are
returned by `SheetsV4.api_object_schemas.keys`.

Raises a runtime error if the object does not conform to the schema.

```Ruby
schema_name = 'BatchUpdateSpreadsheetRequest'
object = { 'requests' => [] }
SheetsV4.validate_api_object(schema_name:, object:)
```

## api_object_schemas

`SheetsV4.api_object_schemas`

A hash of schemas keyed by the schema name loaded from the Google Discovery API

Returns a hash of schemas keyed by schema name.
