### PR TITLE
Improve color api and documentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,6 +28,7 @@ Metrics/ModuleLength:
 
 # When writing minitest tests, it is very hard to limit test class length:
 Metrics/ClassLength:
+  CountAsOne: ['hash']
   Exclude:
     - "test/**/*_test.rb"
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Unofficial helpers for the Google Sheets V4 API
   * [Other Links](#other-links)
 * [Installation](#installation)
 * [Usage](#usage)
+  * [Colors](#colors)
 * [Development](#development)
 * [Creating a Google API Service Account](#creating-a-google-api-service-account)
 * [Contributing](#contributing)
@@ -54,6 +55,19 @@ gem install sheets_v4
 ## Usage
 
 [Detailed API documenation](https://rubydoc.info/gems/sheets_v4/) is hosted on rubygems.org.
+
+### Colors
+
+Color objects (with appropriate :red, :green, :blue values) can be retrieved by name
+using `SheetsV4.color(:black)` or `SheetsV4::Color.black` (these are equivalent).
+
+Color names can be listed using `SheetsV4.color_names`.
+
+The color object returned is a Hash as follows:
+
+```Ruby
+SheetsV4::Color.black #=> {:red=>0.0, :green=>0.0, :blue=>0.0}
+```
 
 ## Development
 

--- a/examples/set_background_color
+++ b/examples/set_background_color
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'sheets_v4'
+require 'googleauth'
+
+# Initialize the API
+
+sheets_service = Google::Apis::SheetsV4::SheetsService.new
+credential = File.open(File.expand_path('~/google-api-examples-credential.json')) do |credential_source|
+  scopes = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
+  options = { json_key_io: credential_source, scope: scopes }
+  Google::Auth::DefaultCredentials.make_creds(options).tap(&:fetch_access_token)
+end
+sheets_service.authorization = credential
+
+# Get the spreadsheet
+
+spreadsheet_id = '18FAcgotK7nDfLTOTQuGCIjKwxkJMAguhn1OVzpFFgWY'
+
+def name_rows
+  SheetsV4.color_names.map do |color_name|
+    { values: [{ user_entered_value: { string_value: color_name.to_s } }] }
+  end
+end
+
+def write_names
+  rows = name_rows
+  fields = 'user_entered_value'
+  start = { sheet_id: 0, row_index: 1, column_index: 0 }
+  { update_cells: { rows:, fields:, start: } }
+end
+
+def background_color_rows
+  SheetsV4.color_names.map { |color_name| SheetsV4.color(color_name) }.map do |color|
+    { values: [{ user_entered_format: { background_color: color } }] }
+  end
+end
+
+def set_background_colors
+  rows = background_color_rows
+  fields = 'user_entered_format'
+  start = { sheet_id: 0, row_index: 1, column_index: 1 }
+  { update_cells: { rows:, fields:, start: } }
+end
+
+request = { requests: [write_names, set_background_colors] }
+
+# SheetsV4.validate_api_object(
+#   schema_name: 'BatchUpdateSpreadsheetRequest', object: request,
+#   logger: Logger.new(STDOUT, level: Logger::ERROR)
+# )
+
+sheets_service.batch_update_spreadsheet(spreadsheet_id, request)

--- a/lib/sheets_v4.rb
+++ b/lib/sheets_v4.rb
@@ -4,6 +4,7 @@ require_relative 'sheets_v4/version'
 require_relative 'sheets_v4/color'
 require_relative 'sheets_v4/validate_api_object'
 
+require 'google/apis/sheets_v4'
 require 'json'
 require 'logger'
 require 'net/http'
@@ -75,168 +76,33 @@ module SheetsV4
     end
   end
 
-  # Return a color object for the given name from SheetsV4::COLORS
+  # Given the name of the color, return a Google Sheets API color object
+  #
+  # Available color names are listed using `SheetsV4.color_names`.
+  #
+  # The object returned is frozen.  If you want a color you can change (for instance,
+  # to adjust the `alpha` attribute), you must clone the object returned.
   #
   # @example
   #   SheetsV4::Color.color(:red) #=> { "red": 1.0, "green": 0.0, "blue": 0.0 }
   #
-  # @param name [Symbol] the name of the color
-  # @return [Hash] the color object
+  # @param name [#to_sym] the name of the color requested
+  #
+  # @return [Hash] The color requested e.g. `{ "red": 1.0, "green": 0.0, "blue": 0.0 }`
+  #
   # @api public
+  #
   def self.color(name)
-    SheetsV4::COLORS[name.to_sym]
+    SheetsV4::Color::COLORS[name.to_sym] || raise("Color #{name} not found")
   end
 
-  # Colors to use in the Google Sheets API
-  COLORS = {
-    # Standard Google Sheets colors
-
-    black: { red: 0.000000000, green: 0.000000000, blue: 0.000000000 },
-    dark_gray4: { red: 0.262745098, green: 0.262745098, blue: 0.262745098 },
-    dark_gray3: { red: 0.400000000, green: 0.400000000, blue: 0.400000000 },
-    dark_gray2: { red: 0.600000000, green: 0.600000000, blue: 0.600000000 },
-    dark_gray1: { red: 0.717647059, green: 0.717647059, blue: 0.717647059 },
-    gray: { red: 0.800000000, green: 0.800000000, blue: 0.800000000 },
-    light_gray1: { red: 0.850980392, green: 0.850980392, blue: 0.850980392 },
-    light_gray2: { red: 0.937254902, green: 0.937254902, blue: 0.937254902 },
-    light_gray3: { red: 0.952941176, green: 0.952941176, blue: 0.952941176 },
-    white: { red: 1.000000000, green: 1.000000000, blue: 1.000000000 },
-    red_berry: { red: 0.596078431, green: 0.000000000, blue: 0.000000000 },
-    red: { red: 1.000000000, green: 0.000000000, blue: 0.000000000 },
-    orange: { red: 1.000000000, green: 0.600000000, blue: 0.000000000 },
-    yellow: { red: 1.000000000, green: 1.000000000, blue: 0.000000000 },
-    green: { red: 0.000000000, green: 1.000000000, blue: 0.000000000 },
-    cyan: { red: 0.000000000, green: 1.000000000, blue: 1.000000000 },
-    cornflower_blue: { red: 0.290196078, green: 0.525490196, blue: 0.909803922 },
-    blue: { red: 0.000000000, green: 0.000000000, blue: 1.000000000 },
-    purple: { red: 0.600000000, green: 0.000000000, blue: 1.000000000 },
-    magenta: { red: 1.000000000, green: 0.000000000, blue: 1.000000000 },
-    light_red_berry3: { red: 0.901960784, green: 0.721568627, blue: 0.686274510 },
-    light_red3: { red: 0.956862745, green: 0.800000000, blue: 0.800000000 },
-    light_orange3: { red: 0.988235294, green: 0.898039216, blue: 0.803921569 },
-    light_yellow3: { red: 1.000000000, green: 0.949019608, blue: 0.800000000 },
-    light_green3: { red: 0.850980392, green: 0.917647059, blue: 0.827450980 },
-    light_cyan3: { red: 0.815686275, green: 0.878431373, blue: 0.890196078 },
-    light_cornflower_blue3: { red: 0.788235294, green: 0.854901961, blue: 0.972549020 },
-    light_blue3: { red: 0.811764706, green: 0.886274510, blue: 0.952941176 },
-    light_purple3: { red: 0.850980392, green: 0.823529412, blue: 0.913725490 },
-    light_magenta3: { red: 0.917647059, green: 0.819607843, blue: 0.862745098 },
-    light_red_berry2: { red: 0.866666667, green: 0.494117647, blue: 0.419607843 },
-    light_red2: { red: 0.917647059, green: 0.600000000, blue: 0.600000000 },
-    light_orange2: { red: 0.976470588, green: 0.796078431, blue: 0.611764706 },
-    light_yellow2: { red: 1.000000000, green: 0.898039216, blue: 0.600000000 },
-    light_green2: { red: 0.713725490, green: 0.843137255, blue: 0.658823529 },
-    light_cyan2: { red: 0.635294118, green: 0.768627451, blue: 0.788235294 },
-    light_cornflower_blue2: { red: 0.643137255, green: 0.760784314, blue: 0.956862745 },
-    light_blue2: { red: 0.623529412, green: 0.772549020, blue: 0.909803922 },
-    light_purple2: { red: 0.705882353, green: 0.654901961, blue: 0.839215686 },
-    light_magenta2: { red: 0.835294118, green: 0.650980392, blue: 0.741176471 },
-    light_red_berry1: { red: 0.800000000, green: 0.254901961, blue: 0.145098039 },
-    light_red1: { red: 0.878431373, green: 0.400000000, blue: 0.400000000 },
-    light_orange1: { red: 0.964705882, green: 0.698039216, blue: 0.419607843 },
-    light_yellow1: { red: 1.000000000, green: 0.850980392, blue: 0.400000000 },
-    light_green1: { red: 0.576470588, green: 0.768627451, blue: 0.490196078 },
-    light_cyan1: { red: 0.462745098, green: 0.647058824, blue: 0.686274510 },
-    light_cornflower_blue1: { red: 0.427450980, green: 0.619607843, blue: 0.921568627 },
-    light_blue1: { red: 0.435294118, green: 0.658823529, blue: 0.862745098 },
-    light_purple1: { red: 0.556862745, green: 0.486274510, blue: 0.764705882 },
-    light_magenta1: { red: 0.760784314, green: 0.482352941, blue: 0.627450980 },
-    dark_red_berry1: { red: 0.650980392, green: 0.109803922, blue: 0.000000000 },
-    dark_red1: { red: 0.800000000, green: 0.000000000, blue: 0.000000000 },
-    dark_orange1: { red: 0.901960784, green: 0.568627451, blue: 0.219607843 },
-    dark_yellow1: { red: 0.945098039, green: 0.760784314, blue: 0.196078431 },
-    dark_green1: { red: 0.415686275, green: 0.658823529, blue: 0.309803922 },
-    dark_cyan1: { red: 0.270588235, green: 0.505882353, blue: 0.556862745 },
-    dark_cornflower_blue1: { red: 0.235294118, green: 0.470588235, blue: 0.847058824 },
-    dark_blue1: { red: 0.239215686, green: 0.521568627, blue: 0.776470588 },
-    dark_purple1: { red: 0.403921569, green: 0.305882353, blue: 0.654901961 },
-    dark_magenta1: { red: 0.650980392, green: 0.301960784, blue: 0.474509804 },
-    dark_red_berry2: { red: 0.521568627, green: 0.125490196, blue: 0.047058824 },
-    dark_red2: { red: 0.600000000, green: 0.000000000, blue: 0.000000000 },
-    dark_orange2: { red: 0.705882353, green: 0.372549020, blue: 0.023529412 },
-    dark_yellow2: { red: 0.749019608, green: 0.564705882, blue: 0.000000000 },
-    dark_green2: { red: 0.219607843, green: 0.462745098, blue: 0.113725490 },
-    dark_cyan2: { red: 0.074509804, green: 0.309803922, blue: 0.360784314 },
-    dark_cornflower_blue2: { red: 0.066666667, green: 0.333333333, blue: 0.800000000 },
-    dark_blue2: { red: 0.043137255, green: 0.325490196, blue: 0.580392157 },
-    dark_purple2: { red: 0.207843137, green: 0.109803922, blue: 0.458823529 },
-    dark_magenta2: { red: 0.454901961, green: 0.105882353, blue: 0.278431373 },
-    dark_red_berry3: { red: 0.356862745, green: 0.058823529, blue: 0.000000000 },
-    dark_red3: { red: 0.400000000, green: 0.000000000, blue: 0.000000000 },
-    dark_orange3: { red: 0.470588235, green: 0.247058824, blue: 0.015686275 },
-    dark_yellow3: { red: 0.498039216, green: 0.376470588, blue: 0.000000000 },
-    dark_green3: { red: 0.152941176, green: 0.305882353, blue: 0.074509804 },
-    darn_cyan3: { red: 0.047058824, green: 0.203921569, blue: 0.239215686 },
-    dark_cornflower_blue3: { red: 0.109803922, green: 0.270588235, blue: 0.529411765 },
-    dark_blue3: { red: 0.027450980, green: 0.215686275, blue: 0.388235294 },
-    dark_purple3: { red: 0.125490196, green: 0.070588235, blue: 0.301960784 },
-    dark_magenta3: { red: 0.298039216, green: 0.066666667, blue: 0.188235294 },
-
-    # Yahoo brand colors
-
-    grape_jelly: { red: 0.376470588, green: 0.003921569, blue: 0.823529412 },
-    hulk_pants: { red: 0.494117647, green: 0.121568627, blue: 1.000000000 },
-    malbec: { red: 0.223529412, green: 0.000000000, blue: 0.490196078 },
-    tumeric: { red: 1.000000000, green: 0.654901961, blue: 0.000000000 },
-    mulah: { red: 0.101960784, green: 0.772549020, blue: 0.403921569 },
-    dory: { red: 0.058823529, green: 0.411764706, blue: 1.000000000 },
-    malibu: { red: 1.000000000, green: 0.000000000, blue: 0.501960784 },
-    sea_foam: { red: 0.066666667, green: 0.827450980, blue: 0.803921569 },
-    tumeric_tint: { red: 0.980392157, green: 0.866666667, blue: 0.694117647 },
-    mulah_tint: { red: 0.733333333, green: 0.901960784, blue: 0.776470588 },
-    dory_tint: { red: 0.662745098, green: 0.772549020, blue: 0.984313725 },
-    malibu_tint: { red: 0.968627451, green: 0.682352941, blue: 0.800000000 },
-    sea_foam_tint: { red: 0.749019608, green: 0.925490196, blue: 0.921568627 },
-
-    # Yahoo health colors
-
-    health_green: { red: 0.000000000, green: 0.690196078, blue: 0.313725490 },
-    health_yellow: { red: 1.000000000, green: 0.654901961, blue: 0.000000000 },
-    health_red: { red: 1.000000000, green: 0.000000000, blue: 0.000000000 },
-
-    # Yahoo Fuji design color palette
-
-    fuji_color_watermelon: { red: 1.000000000, green: 0.321568627, blue: 0.341176471 },
-    fuji_color_solo_cup: { red: 0.921568627, green: 0.058823529, blue: 0.160784314 },
-    fuji_color_malibu: { red: 1.000000000, green: 0.000000000, blue: 0.501960784 },
-    fuji_color_barney: { red: 0.800000000, green: 0.000000000, blue: 0.549019608 },
-    fuji_color_mimosa: { red: 1.000000000, green: 0.827450980, blue: 0.200000000 },
-    fuji_color_turmeric: { red: 1.000000000, green: 0.654901961, blue: 0.000000000 },
-    fuji_color_cheetos: { red: 0.992156863, green: 0.380392157, blue: 0.000000000 },
-    fuji_color_carrot_juice: { red: 1.000000000, green: 0.321568627, blue: 0.050980392 },
-    fuji_color_mulah: { red: 0.101960784, green: 0.772549020, blue: 0.403921569 },
-    fuji_color_bonsai: { red: 0.000000000, green: 0.529411765, blue: 0.317647059 },
-    fuji_color_spirulina: { red: 0.000000000, green: 0.627450980, blue: 0.627450980 },
-    fuji_color_sea_foam: { red: 0.066666667, green: 0.827450980, blue: 0.803921569 },
-    fuji_color_peeps: { red: 0.490196078, green: 0.796078431, blue: 1.000000000 },
-    fuji_color_sky: { red: 0.070588235, green: 0.662745098, blue: 1.000000000 },
-    fuji_color_dory: { red: 0.058823529, green: 0.411764706, blue: 1.000000000 },
-    fuji_color_scooter: { red: 0.000000000, green: 0.388235294, blue: 0.921568627 },
-    fuji_color_cobalt: { red: 0.000000000, green: 0.227450980, blue: 0.737254902 },
-    fuji_color_denim: { red: 0.101960784, green: 0.050980392, blue: 0.670588235 },
-    fuji_color_blurple: { red: 0.364705882, green: 0.368627451, blue: 1.000000000 },
-    fuji_color_hendrix: { red: 0.972549020, green: 0.956862745, blue: 1.000000000 },
-    fuji_color_thanos: { red: 0.564705882, green: 0.486274510, blue: 1.000000000 },
-    fuji_color_starfish: { red: 0.466666667, green: 0.349019608, blue: 1.000000000 },
-    fuji_color_hulk_pants: { red: 0.494117647, green: 0.121568627, blue: 1.000000000 },
-    fuji_color_grape_jelly: { red: 0.376470588, green: 0.003921569, blue: 0.823529412 },
-    fuji_color_mulberry: { red: 0.313725490, green: 0.082352941, blue: 0.690196078 },
-    fuji_color_malbec: { red: 0.223529412, green: 0.000000000, blue: 0.490196078 },
-    fuji_grayscale_black: { red: 0.000000000, green: 0.000000000, blue: 0.000000000 },
-    fuji_grayscale_midnight: { red: 0.062745098, green: 0.082352941, blue: 0.094117647 },
-    fuji_grayscale_inkwell: { red: 0.113725490, green: 0.133333333, blue: 0.156862745 },
-    fuji_grayscale_batcave: { red: 0.137254902, green: 0.164705882, blue: 0.192156863 },
-    fuji_grayscale_ramones: { red: 0.172549020, green: 0.211764706, blue: 0.247058824 },
-    fuji_grayscale_charcoal: { red: 0.274509804, green: 0.305882353, blue: 0.337254902 },
-    fuji_grayscale_battleship: { red: 0.356862745, green: 0.388235294, blue: 0.415686275 },
-    fuji_grayscale_dolphin: { red: 0.431372549, green: 0.466666667, blue: 0.501960784 },
-    fuji_grayscale_shark: { red: 0.509803922, green: 0.541176471, blue: 0.576470588 },
-    fuji_grayscale_gandalf: { red: 0.592156863, green: 0.619607843, blue: 0.658823529 },
-    fuji_grayscale_bob: { red: 0.690196078, green: 0.725490196, blue: 0.756862745 },
-    fuji_grayscale_pebble: { red: 0.780392157, green: 0.803921569, blue: 0.823529412 },
-    fuji_grayscale_dirty_seagull: { red: 0.878431373, green: 0.894117647, blue: 0.913725490 },
-    fuji_grayscale_grey_hair: { red: 0.941176471, green: 0.952941176, blue: 0.960784314 },
-    fuji_grayscale_marshmallow: { red: 0.960784314, green: 0.972549020, blue: 0.980392157 },
-    fuji_grayscale_white: { red: 1.000000000, green: 1.000000000, blue: 1.000000000 }
-  }.freeze
+  # List the names of the colors available to use in the Google Sheets API
+  #
+  # @example
+  #   SheetsV4::Color.color_names #=> [:black, :white, :red, :green, :blue, :yellow, :magenta, :cyan, ...]
+  #
+  # @return [Array<Symbol>] the names of the colors available
+  # @api public
+  #
+  def self.color_names = SheetsV4::Color::COLORS.keys
 end

--- a/lib/sheets_v4/color.rb
+++ b/lib/sheets_v4/color.rb
@@ -3,30 +3,195 @@
 require 'json_schemer'
 
 module SheetsV4
-  # Predefined color objects
+  # Returns predefined color objects by name
+  #
+  # A method is implemented for each color name. The list of available colors is
+  # given by `SheetsV4.color_names`.
+  #
+  # @example
+  #   # Get a color object by name:
+  #   SheetsV4::Color.black #=> { "red" => 0.0, "green" => 0.0, "blue" => 0.0 }
+  #
+  # @see SheetsV4.color a method that returns a color object by name
+  # @see SheetsV4.color_names an array of predefined color names
+  #
   # @api public
+  #
   class Color
     class << self
-      # Return a color object for the given name from SheetsV4::COLORS or call super
+      # Return a color object for the given name from SheetsV4.color_names or call super
       #
-      # @param method_name [Symbol] the name of the color
+      # @param method_name [#to_sym] the name of the color
       # @param arguments [Array] ignored
       # @param block [Proc] ignored
       # @return [Hash] the color object
       # @api private
       def method_missing(method_name, *arguments, &)
-        SheetsV4::COLORS[method_name.to_sym] || super
+        COLORS[method_name.to_sym] || super
       end
 
       # Return true if the given method name is a color name or call super
       #
-      # @param method_name [Symbol] the name of the color
+      # @param method_name [#to_sym] the name of the color
       # @param include_private [Boolean] ignored
       # @return [Boolean] true if the method name is a color name
       # @api private
       def respond_to_missing?(method_name, include_private = false)
-        SheetsV4::COLORS.key?(method_name.to_sym) || super
+        COLORS.key?(method_name.to_sym) || super
       end
     end
+
+    # Colors to use in the Google Sheets API
+    COLORS = {
+      # Standard Google Sheets colors
+      #
+      black: { red: 0.00000000000, green: 0.00000000000, blue: 0.00000000000 },
+      dark_gray4: { red: 0.26274509804, green: 0.26274509804, blue: 0.26274509804 },
+      dark_gray3: { red: 0.40000000000, green: 0.40000000000, blue: 0.40000000000 },
+      dark_gray2: { red: 0.60000000000, green: 0.60000000000, blue: 0.60000000000 },
+      dark_gray1: { red: 0.71764705882, green: 0.71764705882, blue: 0.71764705882 },
+      gray: { red: 0.80000000000, green: 0.80000000000, blue: 0.80000000000 },
+      light_gray1: { red: 0.85098039216, green: 0.85098039216, blue: 0.85098039216 },
+      light_gray2: { red: 0.93725490196, green: 0.93725490196, blue: 0.93725490196 },
+      light_gray3: { red: 0.95294117647, green: 0.95294117647, blue: 0.95294117647 },
+      white: { red: 1.00000000000, green: 1.00000000000, blue: 1.00000000000 },
+      red_berry: { red: 0.59607843137, green: 0.00000000000, blue: 0.00000000000 },
+      red: { red: 1.00000000000, green: 0.00000000000, blue: 0.00000000000 },
+      orange: { red: 1.00000000000, green: 0.60000000000, blue: 0.00000000000 },
+      yellow: { red: 1.00000000000, green: 1.00000000000, blue: 0.00000000000 },
+      green: { red: 0.00000000000, green: 1.00000000000, blue: 0.00000000000 },
+      cyan: { red: 0.00000000000, green: 1.00000000000, blue: 1.00000000000 },
+      cornflower_blue: { red: 0.29019607843, green: 0.52549019608, blue: 0.90980392157 },
+      blue: { red: 0.00000000000, green: 0.00000000000, blue: 1.00000000000 },
+      purple: { red: 0.60000000000, green: 0.00000000000, blue: 1.00000000000 },
+      magenta: { red: 1.00000000000, green: 0.00000000000, blue: 1.00000000000 },
+      light_red_berry3: { red: 0.90196078431, green: 0.72156862745, blue: 0.68627450980 },
+      light_red3: { red: 0.95686274510, green: 0.80000000000, blue: 0.80000000000 },
+      light_orange3: { red: 0.98823529412, green: 0.89803921569, blue: 0.80392156863 },
+      light_yellow3: { red: 1.00000000000, green: 0.94901960784, blue: 0.80000000000 },
+      light_green3: { red: 0.85098039216, green: 0.91764705882, blue: 0.82745098039 },
+      light_cyan3: { red: 0.81568627451, green: 0.87843137255, blue: 0.89019607843 },
+      light_cornflower_blue3: { red: 0.78823529412, green: 0.85490196078, blue: 0.97254901961 },
+      light_blue3: { red: 0.81176470588, green: 0.88627450980, blue: 0.95294117647 },
+      light_purple3: { red: 0.85098039216, green: 0.82352941176, blue: 0.91372549020 },
+      light_magenta3: { red: 0.91764705882, green: 0.81960784314, blue: 0.86274509804 },
+      light_red_berry2: { red: 0.86666666667, green: 0.49411764706, blue: 0.41960784314 },
+      light_red2: { red: 0.91764705882, green: 0.60000000000, blue: 0.60000000000 },
+      light_orange2: { red: 0.97647058824, green: 0.79607843137, blue: 0.61176470588 },
+      light_yellow2: { red: 1.00000000000, green: 0.89803921569, blue: 0.60000000000 },
+      light_green2: { red: 0.71372549020, green: 0.84313725490, blue: 0.65882352941 },
+      light_cyan2: { red: 0.63529411765, green: 0.76862745098, blue: 0.78823529412 },
+      light_cornflower_blue2: { red: 0.64313725490, green: 0.76078431373, blue: 0.95686274510 },
+      light_blue2: { red: 0.62352941176, green: 0.77254901961, blue: 0.90980392157 },
+      light_purple2: { red: 0.70588235294, green: 0.65490196078, blue: 0.83921568627 },
+      light_magenta2: { red: 0.83529411765, green: 0.65098039216, blue: 0.74117647059 },
+      light_red_berry1: { red: 0.80000000000, green: 0.25490196078, blue: 0.14509803922 },
+      light_red1: { red: 0.87843137255, green: 0.40000000000, blue: 0.40000000000 },
+      light_orange1: { red: 0.96470588235, green: 0.69803921569, blue: 0.41960784314 },
+      light_yellow1: { red: 1.00000000000, green: 0.85098039216, blue: 0.40000000000 },
+      light_green1: { red: 0.57647058824, green: 0.76862745098, blue: 0.49019607843 },
+      light_cyan1: { red: 0.46274509804, green: 0.64705882353, blue: 0.68627450980 },
+      light_cornflower_blue1: { red: 0.42745098039, green: 0.61960784314, blue: 0.92156862745 },
+      light_blue1: { red: 0.43529411765, green: 0.65882352941, blue: 0.86274509804 },
+      light_purple1: { red: 0.55686274510, green: 0.48627450980, blue: 0.76470588235 },
+      light_magenta1: { red: 0.76078431373, green: 0.48235294118, blue: 0.62745098039 },
+      dark_red_berry1: { red: 0.65098039216, green: 0.10980392157, blue: 0.00000000000 },
+      dark_red1: { red: 0.80000000000, green: 0.00000000000, blue: 0.00000000000 },
+      dark_orange1: { red: 0.90196078431, green: 0.56862745098, blue: 0.21960784314 },
+      dark_yellow1: { red: 0.94509803922, green: 0.76078431373, blue: 0.19607843137 },
+      dark_green1: { red: 0.41568627451, green: 0.65882352941, blue: 0.30980392157 },
+      dark_cyan1: { red: 0.27058823529, green: 0.50588235294, blue: 0.55686274510 },
+      dark_cornflower_blue1: { red: 0.23529411765, green: 0.47058823529, blue: 0.84705882353 },
+      dark_blue1: { red: 0.23921568627, green: 0.52156862745, blue: 0.77647058824 },
+      dark_purple1: { red: 0.40392156863, green: 0.30588235294, blue: 0.65490196078 },
+      dark_magenta1: { red: 0.65098039216, green: 0.30196078431, blue: 0.47450980392 },
+      dark_red_berry2: { red: 0.52156862745, green: 0.12549019608, blue: 0.04705882353 },
+      dark_red2: { red: 0.60000000000, green: 0.00000000000, blue: 0.00000000000 },
+      dark_orange2: { red: 0.70588235294, green: 0.37254901961, blue: 0.02352941176 },
+      dark_yellow2: { red: 0.74901960784, green: 0.56470588235, blue: 0.00000000000 },
+      dark_green2: { red: 0.21960784314, green: 0.46274509804, blue: 0.11372549020 },
+      dark_cyan2: { red: 0.07450980392, green: 0.30980392157, blue: 0.36078431373 },
+      dark_cornflower_blue2: { red: 0.06666666667, green: 0.33333333333, blue: 0.80000000000 },
+      dark_blue2: { red: 0.04313725490, green: 0.32549019608, blue: 0.58039215686 },
+      dark_purple2: { red: 0.20784313725, green: 0.10980392157, blue: 0.45882352941 },
+      dark_magenta2: { red: 0.45490196078, green: 0.10588235294, blue: 0.27843137255 },
+      dark_red_berry3: { red: 0.35686274510, green: 0.05882352941, blue: 0.00000000000 },
+      dark_red3: { red: 0.40000000000, green: 0.00000000000, blue: 0.00000000000 },
+      dark_orange3: { red: 0.47058823529, green: 0.24705882353, blue: 0.01568627451 },
+      dark_yellow3: { red: 0.49803921569, green: 0.37647058824, blue: 0.00000000000 },
+      dark_green3: { red: 0.15294117647, green: 0.30588235294, blue: 0.07450980392 },
+      darn_cyan3: { red: 0.04705882353, green: 0.20392156863, blue: 0.23921568627 },
+      dark_cornflower_blue3: { red: 0.10980392157, green: 0.27058823529, blue: 0.52941176471 },
+      dark_blue3: { red: 0.02745098039, green: 0.21568627451, blue: 0.38823529412 },
+      dark_purple3: { red: 0.12549019608, green: 0.07058823529, blue: 0.30196078431 },
+      dark_magenta3: { red: 0.29803921569, green: 0.06666666667, blue: 0.18823529412 },
+
+      # Yahoo brand colors
+      #
+      grape_jelly: { red: 0.37647058824, green: 0.00392156863, blue: 0.82352941176 },
+      hulk_pants: { red: 0.49411764706, green: 0.12156862745, blue: 1.00000000000 },
+      malbec: { red: 0.22352941176, green: 0.00000000000, blue: 0.49019607843 },
+      tumeric: { red: 1.00000000000, green: 0.65490196078, blue: 0.00000000000 },
+      mulah: { red: 0.10196078431, green: 0.77254901961, blue: 0.40392156863 },
+      dory: { red: 0.05882352941, green: 0.41176470588, blue: 1.00000000000 },
+      malibu: { red: 1.00000000000, green: 0.00000000000, blue: 0.50196078431 },
+      sea_foam: { red: 0.06666666667, green: 0.82745098039, blue: 0.80392156863 },
+      tumeric_tint: { red: 0.98039215686, green: 0.86666666667, blue: 0.69411764706 },
+      mulah_tint: { red: 0.73333333333, green: 0.90196078431, blue: 0.77647058824 },
+      dory_tint: { red: 0.66274509804, green: 0.77254901961, blue: 0.98431372549 },
+      malibu_tint: { red: 0.96862745098, green: 0.68235294118, blue: 0.80000000000 },
+      sea_foam_tint: { red: 0.74901960784, green: 0.92549019608, blue: 0.92156862745 },
+
+      # Yahoo health colors
+      #
+      health_green: { red: 0.00000000000, green: 0.69019607843, blue: 0.31372549020 },
+      health_yellow: { red: 1.00000000000, green: 0.65490196078, blue: 0.00000000000 },
+      health_red: { red: 1.00000000000, green: 0.00000000000, blue: 0.00000000000 },
+
+      # Yahoo Fuji design color palette
+      #
+      fuji_color_watermelon: { red: 1.00000000000, green: 0.32156862745, blue: 0.34117647059 },
+      fuji_color_solo_cup: { red: 0.92156862745, green: 0.05882352941, blue: 0.16078431373 },
+      fuji_color_malibu: { red: 1.00000000000, green: 0.00000000000, blue: 0.50196078431 },
+      fuji_color_barney: { red: 0.80000000000, green: 0.00000000000, blue: 0.54901960784 },
+      fuji_color_mimosa: { red: 1.00000000000, green: 0.82745098039, blue: 0.20000000000 },
+      fuji_color_turmeric: { red: 1.00000000000, green: 0.65490196078, blue: 0.00000000000 },
+      fuji_color_cheetos: { red: 0.99215686275, green: 0.38039215686, blue: 0.00000000000 },
+      fuji_color_carrot_juice: { red: 1.00000000000, green: 0.32156862745, blue: 0.05098039216 },
+      fuji_color_mulah: { red: 0.10196078431, green: 0.77254901961, blue: 0.40392156863 },
+      fuji_color_bonsai: { red: 0.00000000000, green: 0.52941176471, blue: 0.31764705882 },
+      fuji_color_spirulina: { red: 0.00000000000, green: 0.62745098039, blue: 0.62745098039 },
+      fuji_color_sea_foam: { red: 0.06666666667, green: 0.82745098039, blue: 0.80392156863 },
+      fuji_color_peeps: { red: 0.49019607843, green: 0.79607843137, blue: 1.00000000000 },
+      fuji_color_sky: { red: 0.07058823529, green: 0.66274509804, blue: 1.00000000000 },
+      fuji_color_dory: { red: 0.05882352941, green: 0.41176470588, blue: 1.00000000000 },
+      fuji_color_scooter: { red: 0.00000000000, green: 0.38823529412, blue: 0.92156862745 },
+      fuji_color_cobalt: { red: 0.00000000000, green: 0.22745098039, blue: 0.73725490196 },
+      fuji_color_denim: { red: 0.10196078431, green: 0.05098039216, blue: 0.67058823529 },
+      fuji_color_blurple: { red: 0.36470588235, green: 0.36862745098, blue: 1.00000000000 },
+      fuji_color_hendrix: { red: 0.97254901961, green: 0.95686274510, blue: 1.00000000000 },
+      fuji_color_thanos: { red: 0.56470588235, green: 0.48627450980, blue: 1.00000000000 },
+      fuji_color_starfish: { red: 0.46666666667, green: 0.34901960784, blue: 1.00000000000 },
+      fuji_color_hulk_pants: { red: 0.49411764706, green: 0.12156862745, blue: 1.00000000000 },
+      fuji_color_grape_jelly: { red: 0.37647058824, green: 0.00392156863, blue: 0.82352941176 },
+      fuji_color_mulberry: { red: 0.31372549020, green: 0.08235294118, blue: 0.69019607843 },
+      fuji_color_malbec: { red: 0.22352941176, green: 0.00000000000, blue: 0.49019607843 },
+      fuji_grayscale_black: { red: 0.00000000000, green: 0.00000000000, blue: 0.00000000000 },
+      fuji_grayscale_midnight: { red: 0.06274509804, green: 0.08235294118, blue: 0.09411764706 },
+      fuji_grayscale_inkwell: { red: 0.11372549020, green: 0.13333333333, blue: 0.15686274510 },
+      fuji_grayscale_batcave: { red: 0.13725490196, green: 0.16470588235, blue: 0.19215686275 },
+      fuji_grayscale_ramones: { red: 0.17254901961, green: 0.21176470588, blue: 0.24705882353 },
+      fuji_grayscale_charcoal: { red: 0.27450980392, green: 0.30588235294, blue: 0.33725490196 },
+      fuji_grayscale_battleship: { red: 0.35686274510, green: 0.38823529412, blue: 0.41568627451 },
+      fuji_grayscale_dolphin: { red: 0.43137254902, green: 0.46666666667, blue: 0.50196078431 },
+      fuji_grayscale_shark: { red: 0.50980392157, green: 0.54117647059, blue: 0.57647058824 },
+      fuji_grayscale_gandalf: { red: 0.59215686275, green: 0.61960784314, blue: 0.65882352941 },
+      fuji_grayscale_bob: { red: 0.69019607843, green: 0.72549019608, blue: 0.75686274510 },
+      fuji_grayscale_pebble: { red: 0.78039215686, green: 0.80392156863, blue: 0.82352941176 },
+      fuji_grayscale_dirty_seagull: { red: 0.87843137255, green: 0.89411764706, blue: 0.91372549020 },
+      fuji_grayscale_grey_hair: { red: 0.94117647059, green: 0.95294117647, blue: 0.96078431373 },
+      fuji_grayscale_marshmallow: { red: 0.96078431373, green: 0.97254901961, blue: 0.98039215686 },
+      fuji_grayscale_white: { red: 1.00000000000, green: 1.00000000000, blue: 1.00000000000 }
+    }.freeze.each_value(&:freeze)
   end
 end

--- a/spec/sheets_v4/color_spec.rb
+++ b/spec/sheets_v4/color_spec.rb
@@ -2,17 +2,17 @@
 
 RSpec.describe SheetsV4::Color do
   describe '.respond_to?' do
-    it 'should respond to all the SheetsV4::COLORS names' do
-      SheetsV4::COLORS.each_key do |color_name|
+    it 'should respond to all the SheetsV4::Color::COLORS names' do
+      SheetsV4::Color::COLORS.each_key do |color_name|
         expect { described_class.respond_to?(color_name) }.not_to raise_error
       end
     end
   end
 
   describe '.method_missing' do
-    it 'should implement methods for all the SheetsV4::COLORS names' do
-      SheetsV4::COLORS.each_key do |color_name|
-        expect(described_class.send(color_name)).to eq(SheetsV4::COLORS[color_name])
+    it 'should implement methods for all the SheetsV4::Color::COLORS names' do
+      SheetsV4::Color::COLORS.each_key do |color_name|
+        expect(described_class.send(color_name)).to eq(SheetsV4::Color::COLORS[color_name])
       end
     end
   end

--- a/spec/sheets_v4_spec.rb
+++ b/spec/sheets_v4_spec.rb
@@ -76,9 +76,21 @@ RSpec.describe SheetsV4 do
 
   describe '.color' do
     it 'should return the color object for the given name' do
-      SheetsV4::COLORS.each_key do |color_name|
-        expect(described_class.color(color_name)).to eq(SheetsV4::COLORS[color_name])
+      SheetsV4::Color::COLORS.each_key do |color_name|
+        expect(described_class.color(color_name)).to eq(SheetsV4::Color::COLORS[color_name])
       end
+    end
+
+    it 'should return the color object when name is given as a symbol' do
+      expect(described_class.color(:black)).to eq(SheetsV4::Color::COLORS[:black])
+    end
+
+    it 'should return the color object when name is given as a string' do
+      expect(described_class.color('black')).to eq(SheetsV4::Color::COLORS[:black])
+    end
+
+    it 'should raise a RuntimeError if a color is not found' do
+      expect { described_class.color(:non_existant_color) }.to raise_error(RuntimeError)
     end
   end
 end


### PR DESCRIPTION
## API Improvements

Color objects (with appropriate :red, :green, :blue values) can be retrieved by name
using `SheetsV4.color(:black)` or `SheetsV4::Color.black` (these are equivalent).

Color names can be listed using `SheetsV4.color_names`.

The color object returned is a Hash as follows:

```Ruby
SheetsV4::Color.black #=> {:red=>0.0, :green=>0.0, :blue=>0.0}
```

## Data improvements

Extended the precision of the color RGB values.

## Added Example

Added `examples/set_background_color`