### PR TITLE
Add a link in the README to the Sheet V4 API Discover Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Unofficial helpers for the Google Sheets V4 API
 * [Google Sheets API Overview](https://developers.google.com/sheets/api)
 * [Google Sheets API Reference](https://developers.google.com/sheets/api/reference/rest)
 * [Batch Update Requests](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request)
+* [Discovery Document for the Sheets API](https://sheets.googleapis.com/$discovery/rest?version=v4)
 
 ### Ruby Implementation of the Sheets API
 


### PR DESCRIPTION
Add a link to be able to view the Discovery Document for the Sheets V4 API. This JSON document describes the API and is useful when programming the API.

See the [Google API Discovery Service](https://developers.google.com/discovery) for more information.