### PR TITLE
Move loading of the API schemas from SheetsV4 to SheetsV4::ValidateApiObject

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 * [ ] Creating a Google API service account [1](https://www.youtube.com/watch?v=sAgWCbGMzTo&list=PL3JVwFmb_BnSee8RFaRPZ3nykuMRlaQp1&index=1)
 [2](https://www.youtube.com/watch?v=sVURhxyc6jE&list=PL3JVwFmb_BnSee8RFaRPZ3nykuMRlaQp1&index=43)
 * [ ] Create a SheetsService instance
+* [X] Set background color
 * [ ] Creating Google Sheets files [1](https://www.youtube.com/watch?v=JRUxeQ6ZCy0&list=PL3JVwFmb_BnSee8RFaRPZ3nykuMRlaQp1&index=2)
 * [ ] Writing data to a sheet [1](https://www.youtube.com/watch?v=YF7Ad-7pvks&list=PL3JVwFmb_BnSee8RFaRPZ3nykuMRlaQp1&index=3)
 * [ ] Reading data from a sheet [1](https://www.youtube.com/watch?v=gkglr8GID5E&list=PL3JVwFmb_BnSee8RFaRPZ3nykuMRlaQp1&index=4)

--- a/lib/sheets_v4.rb
+++ b/lib/sheets_v4.rb
@@ -36,46 +36,6 @@ module SheetsV4
     ValidateApiObject.new(logger).call(schema_name, object)
   end
 
-  # A hash of schemas keyed by the schema name loaded from the Google Discovery API
-  #
-  # @example
-  #   SheetsV4.api_object_schemas #=> { 'PersonSchema' => { 'type' => 'object', ... } ... }
-  #
-  # @return [Hash<String, Object>] a hash of schemas keyed by schema name
-  #
-  def self.api_object_schemas
-    schema_load_semaphore.synchronize { @api_object_schemas ||= load_api_object_schemas }
-  end
-
-  # Validate
-  # A mutex used to synchronize access to the schemas so they are only loaded
-  # once.
-  #
-  @schema_load_semaphore = Thread::Mutex.new
-
-  # A mutex used to synchronize access to the schemas so they are only loaded once
-  #
-  # @return [Thread::Mutex]
-  #
-  # @api private
-  #
-  def self.schema_load_semaphore = @schema_load_semaphore
-
-  # Load the schemas from the Google Discovery API
-  #
-  # @return [Hash<String, Object>] a hash of schemas keyed by schema name
-  #
-  # @api private
-  #
-  def self.load_api_object_schemas
-    source = 'https://sheets.googleapis.com/$discovery/rest?version=v4'
-    resp = Net::HTTP.get_response(URI.parse(source))
-    data = resp.body
-    JSON.parse(data)['schemas'].tap do |schemas|
-      schemas.each { |_name, schema| schema['unevaluatedProperties'] = false }
-    end
-  end
-
   # Given the name of the color, return a Google Sheets API color object
   #
   # Available color names are listed using `SheetsV4.color_names`.

--- a/spec/sheets_v4_spec.rb
+++ b/spec/sheets_v4_spec.rb
@@ -58,22 +58,6 @@ RSpec.describe SheetsV4 do
     end
   end
 
-  describe '.self.api_object_schemas' do
-    it 'should return the schemas from the Google Discovery API for Sheets V4' do
-      expect(described_class.api_object_schemas).to have_attributes(keys: %w[PersonSchema LocationSchema])
-    end
-
-    it 'should return the PersonSchema adding the unevaluatedProperties=false property' do
-      expected_schema = schemas['PersonSchema'].merge('unevaluatedProperties' => false)
-      expect(described_class.api_object_schemas['PersonSchema']).to eq(expected_schema)
-    end
-
-    it 'should return the LocationSchema adding the unevaluatedProperties=false property' do
-      expected_schema = schemas['LocationSchema'].merge('unevaluatedProperties' => false)
-      expect(described_class.api_object_schemas['LocationSchema']).to eq(expected_schema)
-    end
-  end
-
   describe '.color' do
     it 'should return the color object for the given name' do
       SheetsV4::Color::COLORS.each_key do |color_name|


### PR DESCRIPTION
Move the loading of the API schemas out of SheetsV4 and into SheetsV4::ValidateApiObject where it belongs. This takes unnecessary, private methods out of the SheetsV4 module.