### PR TITLE
Add SheetsV4.sheets_service

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Unofficial helpers for the Google Sheets V4 API
   * [Other Links](#other-links)
 * [Installation](#installation)
 * [Usage](#usage)
+  * [Obtaining an authenticated SheetsService](#obtaining-an-authenticated-sheetsservice)
   * [Colors](#colors)
 * [Development](#development)
 * [Creating a Google API Service Account](#creating-a-google-api-service-account)
@@ -56,6 +57,47 @@ gem install sheets_v4
 ## Usage
 
 [Detailed API documenation](https://rubydoc.info/gems/sheets_v4/) is hosted on rubygems.org.
+
+### Obtaining an authenticated SheetsService
+
+Typically, to construct an authenticated SheetsService object where the credential
+is read from a file, the following code is required:
+
+```Ruby
+sheets_service = Google::Apis::SheetsV4::SheetsService.new
+credential = File.read(File.expand_path('~/google-api-credential.json')) do |credential_source|
+  scopes = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
+  options = { json_key_io: credential_source, scope: scopes }
+  Google::Auth::DefaultCredentials.make_creds(options).tap(&:fetch_access_token)
+end
+sheets_service.authorization = credential
+```
+
+The `SheetsV4.sheets_service` method simplifies this a bit.
+
+By default, the credential is read from `~/.google-api-credential.json`. In that case,
+an authenticated SheetsService object can be obtained with one method call:
+
+```Ruby
+sheets_service = SheetsV4.sheets_service
+```
+
+If the credential is stored elsewhere, pass the credential_source to `SheetsV4.sheets_service`
+manually. `credential_source` can be a String:
+
+```Ruby
+sheets_service = SheetsV4.sheets_service(credential_sourvce: File.read('credential.json'))
+```
+
+an IO object:
+
+```Ruby
+sheets_service = File.open('credential.json') do |credential_source|
+  SheetsV4.sheets_service(credential_sourvce:)
+end
+```
+
+or an already constructed `Google::Auth::*`` object.
 
 ### Colors
 

--- a/examples/set_background_color
+++ b/examples/set_background_color
@@ -4,19 +4,16 @@
 require 'sheets_v4'
 require 'googleauth'
 
-# Initialize the API
+# Example to show using the SheetsV4 module to set the background color of a cell
+#
+# GIVEN the credential file is at ~/.google-api-credential.json
+#   AND the spreadsheet id is 18FAcgotK7nDfLTOTQuGCIjKwxkJMAguhn1OVzpFFgWY
+#   AND the spreadsheet has a sheet whose id is 0
+# WHEN the script is run
+# THEN the sheet whose id is 0 will have the background color names starting at A2
+#   AND the background color of the cells in column B will be set to the color matching the color name in column A
 
-sheets_service = Google::Apis::SheetsV4::SheetsService.new
-credential = File.open(File.expand_path('~/google-api-examples-credential.json')) do |credential_source|
-  scopes = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
-  options = { json_key_io: credential_source, scope: scopes }
-  Google::Auth::DefaultCredentials.make_creds(options).tap(&:fetch_access_token)
-end
-sheets_service.authorization = credential
-
-# Get the spreadsheet
-
-spreadsheet_id = '18FAcgotK7nDfLTOTQuGCIjKwxkJMAguhn1OVzpFFgWY'
+# Build the requests
 
 def name_rows
   SheetsV4.color_names.map do |color_name|
@@ -44,11 +41,12 @@ def set_background_colors
   { update_cells: { rows:, fields:, start: } }
 end
 
-request = { requests: [write_names, set_background_colors] }
+def requests = { requests: [write_names, set_background_colors] }
 
 # SheetsV4.validate_api_object(
 #   schema_name: 'BatchUpdateSpreadsheetRequest', object: request,
 #   logger: Logger.new(STDOUT, level: Logger::ERROR)
 # )
 
-sheets_service.batch_update_spreadsheet(spreadsheet_id, request)
+spreadsheet_id = '18FAcgotK7nDfLTOTQuGCIjKwxkJMAguhn1OVzpFFgWY'
+SheetsV4.sheets_service.batch_update_spreadsheet(spreadsheet_id, requests)

--- a/lib/sheets_v4.rb
+++ b/lib/sheets_v4.rb
@@ -2,6 +2,7 @@
 
 require_relative 'sheets_v4/version'
 require_relative 'sheets_v4/color'
+require_relative 'sheets_v4/credential_creator'
 require_relative 'sheets_v4/validate_api_object'
 
 require 'google/apis/sheets_v4'
@@ -14,6 +15,38 @@ require 'net/http'
 # @api public
 #
 module SheetsV4
+  # Create a new Google::Apis::SheetsV4::SheetsService object
+  #
+  # Simplifies creating and configuring a the credential.
+  #
+  # @example using the crednetial in `~/.google-api-credential`
+  #   SheetsV4.sheets_service
+  #
+  # @example using a credential passed in as a string
+  #   credential_source = File.read(File.join(Dir.home, '.credential'))
+  #   SheetsV4.sheets_service(credential_source:
+  #
+  # @param credential_source [nil, String, IO, Google::Auth::*] may
+  #   be either an already constructed credential, the credential read into a String or
+  #   an open file with the credential ready to be read. Passing `nil` will result
+  #   in the credential being read from `~/.google-api-credential.json`.
+  #
+  # @param scopes [Object, Array] one or more scopes to access.
+  #
+  # @param credential_creator [#credential] Used to inject the credential creator for
+  #   testing.
+  #
+  # @return a new SheetsService instance
+  #
+  def self.sheets_service(credential_source: nil, scopes: nil, credential_creator: SheetsV4::CredentialCreator)
+    credential_source ||= File.read(File.expand_path('~/.google-api-credential.json'))
+    scopes ||= [Google::Apis::SheetsV4::AUTH_SPREADSHEETS]
+
+    Google::Apis::SheetsV4::SheetsService.new.tap do |service|
+      service.authorization = credential_creator.call(credential_source, scopes)
+    end
+  end
+
   # Validate the object using the named JSON schema
   #
   # The JSON schemas are loaded from the Google Disocvery API. The schemas names are

--- a/lib/sheets_v4/credential_creator.rb
+++ b/lib/sheets_v4/credential_creator.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'json_schemer'
+
+module SheetsV4
+  # Creates a Google API credential with an access token
+  #
+  class CredentialCreator
+    # Creates a Google API credential with an access token
+    #
+    # This wraps the boiler plate code into one function to make constructing a
+    # credential easy and less error prone.
+    #
+    # @example Constructing a credential from the contents of ~/.credential
+    #   credential_source = File.read(File.join(Dir.home, '.credential'))
+    #   scope = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
+    #   credential = GoogleApisHelpers.credential(credential_source, scope)
+    #
+    # @param [Google::Auth::*, String, IO, nil] credential_source may be one of four things:
+    #   (1) a previously created credential that you want to reuse, (2) a credential read
+    #   into a string, (3) an IO object with the credential ready to be read, or (4)
+    #   if nill, the credential is read from ~/.google-api-credential.json
+    # @param scopes [Object, Array] one or more scopes to access.
+    # @param credential_factory [#make_creds] Used inject the credential_factory for tests
+    #
+    # @return [Object] a credential object with an access token
+    #
+    def self.call(
+      credential_source, scopes, credential_factory = Google::Auth::DefaultCredentials
+    )
+      return credential_source if credential?(credential_source)
+
+      credential_source ||= default_credential_source
+      options = make_creds_options(credential_source, scopes)
+      credential_factory.make_creds(options).tap(&:fetch_access_token)
+    end
+
+    private
+
+    # Reads credential source from `~/.google-api-credential.json`
+    #
+    # @return [String] the credential as a string
+    #
+    # @api private
+    #
+    private_class_method def self.default_credential_source
+      File.read(File.expand_path('~/.google-api-credential.json'))
+    end
+
+    # Constructs creds_options needed to create a credential
+    #
+    # @param [Google::Auth::*, String, #read] credential_source a credential (which
+    #   is an object whose class is in the Google::Auth module), a String containing
+    #   the credential, or a IO object with the credential ready to be read.
+    #
+    # @return [Hash] returns the cred_options
+    #
+    # @api private
+    #
+    private_class_method def self.make_creds_options(credential_source, scopes)
+      { json_key_io: to_io(credential_source), scope: scopes }
+    end
+
+    # Wraps a credential_source that is a string in a StringIO
+    #
+    # @param [Google::Auth::*, String, #read] credential_source a credential (which
+    #   is an object whose class is in the Google::Auth module), a String containing
+    #   the credential, or a IO object with the credential ready to be read.
+    #
+    # @return [IO, StringIO] returns a StringIO object is a String was passed in.
+    #
+    # @api private
+    #
+    private_class_method def self.to_io(credential_source)
+      credential_source.is_a?(String) ? StringIO.new(credential_source) : credential_source
+    end
+
+    # Determines if a credential_source is already a credential
+    #
+    # @param [Google::Auth::*, String, #read] credential_source a credential (which
+    #   is an object whose class is in the Google::Auth module), a String containing
+    #   the credential, or a IO object with the credential ready to be read.
+    #
+    # @return [Boolean] true if the credential source is an object whose class is in the
+    #   Google::Auth module.
+    #
+    # @api private
+    #
+    private_class_method def self.credential?(credential_source)
+      credential_source.class.name.start_with?('Google::Auth::')
+    end
+  end
+end

--- a/spec/sheets_v4/credential_creator_spec.rb
+++ b/spec/sheets_v4/credential_creator_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+RSpec.describe SheetsV4::CredentialCreator do
+  describe '.call' do
+    subject { described_class.call(credential_source, scopes, credential_factory) }
+
+    let(:scopes) { double('scopes') }
+    let(:credential_factory) { double('credential_factory') }
+
+    context 'credential_source is a Google::Auth::*' do
+      let(:credential_source) do
+        double('credential_source', class: double('credential_class', name: 'Google::Auth::Test'))
+      end
+
+      it 'should use return the credential_source' do
+        expect(subject).to eq(credential_source)
+      end
+    end
+
+    context 'credential_source is a String' do
+      let(:credential_source) { 'credential as a string' }
+      let(:credential) { double('credential') }
+      it 'should use the string to make the credential' do
+        expect(credential_factory).to(
+          receive(:make_creds)
+            .with({ json_key_io: StringIO, scope: scopes })
+            .and_return(credential)
+        )
+        expect(credential).to receive(:fetch_access_token)
+        expect(subject).to eq(credential)
+      end
+    end
+
+    context 'credential_source is an IO' do
+      let(:credential_source) { StringIO.new('credential as a string') }
+      let(:credential) { double('credential') }
+      it 'should read the credential from the IO object' do
+        expect(credential_factory).to(
+          receive(:make_creds)
+            .with({ json_key_io: credential_source, scope: scopes })
+            .and_return(credential)
+        )
+        expect(credential).to receive(:fetch_access_token)
+        expect(subject).to eq(credential)
+      end
+    end
+
+    context 'credential_source is nil' do
+      let(:credential_source) { nil }
+      let(:credential) { double('credential') }
+      it 'should read the credential from ~/.google-api-credential.json' do
+        allow(File).to receive(:expand_path).and_call_original
+        allow(File).to receive(:read).and_call_original
+        expect(File).to receive(:expand_path).with('~/.google-api-credential.json').and_return('path')
+        expect(File).to receive(:read).with('path').and_return('credential as a string')
+
+        expect(credential_factory).to(
+          receive(:make_creds)
+            .with({ json_key_io: StringIO, scope: scopes })
+            .and_return(credential)
+        )
+
+        expect(credential).to receive(:fetch_access_token)
+        expect(subject).to eq(credential)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add SheetsV4.sheets_service which simplifies the authentication steps needed to create a Google::Apis::SheetsV4::SheetsService object.

Typically, to construct an authenticated SheetsService object where the credential
is read from a file, the following code is required:

```Ruby
sheets_service = Google::Apis::SheetsV4::SheetsService.new
credential = File.read(File.expand_path('~/google-api-credential.json')) do |credential_source|
  scopes = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
  options = { json_key_io: credential_source, scope: scopes }
  Google::Auth::DefaultCredentials.make_creds(options).tap(&:fetch_access_token)
end
sheets_service.authorization = credential
```

The `SheetsV4.sheets_service` method simplifies this a bit.

By default, the credential is read from `~/.google-api-credential.json`. In that case,
an authenticated SheetsService object can be obtained with one method call:

```Ruby
sheets_service = SheetsV4.sheets_service
```

If the credential is stored elsewhere, pass the credential_source to `SheetsV4.sheets_service`
manually. `credential_source` can be a String:

```Ruby
sheets_service = SheetsV4.sheets_service(credential_sourvce: File.read('credential.json'))
```

an IO object:

```Ruby
sheets_service = File.open('credential.json') do |credential_source|
  SheetsV4.sheets_service(credential_sourvce:)
end
```

or an already constructed `Google::Auth::*`` object.
