### PR TITLE
Update documentation explaining how to construct and validate a request

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,36 +9,26 @@
 
 Unofficial helpers for the Google Sheets V4 API
 
-* [Important Links for Programming Google Sheets](#important-links-for-programming-google-sheets)
-  * [General API Documentation](#general-api-documentation)
-  * [Ruby Implementation of the Sheets API](#ruby-implementation-of-the-sheets-api)
-  * [Other Links](#other-links)
 * [Installation](#installation)
+* [Important links for programming Google Sheets](#important-links-for-programming-google-sheets)
+  * [General API documentation](#general-api-documentation)
+  * [Ruby implementation of the Sheets API](#ruby-implementation-of-the-sheets-api)
+  * [Other Links](#other-links)
+* [Getting Started](#getting-started)
+  * [Creating a Google Cloud project](#creating-a-google-cloud-project)
+  * [Enable the APIs you want to use](#enable-the-apis-you-want-to-use)
+  * [Create a Google API credentials](#create-a-google-api-credentials)
 * [Usage](#usage)
   * [Obtaining an authenticated SheetsService](#obtaining-an-authenticated-sheetsservice)
+  * [Building a request](#building-a-request)
+    * [Method 1: constructing requests using `Google::Apis::SheetsV4::*` objects](#method-1-constructing-requests-using-googleapissheetsv4-objects)
+    * [Method 2: constructing requests using hashes](#method-2-constructing-requests-using-hashes)
+    * [Which method should be used?](#which-method-should-be-used)
+  * [Validating requests](#validating-requests)
   * [Colors](#colors)
 * [Development](#development)
-* [Creating a Google API Service Account](#creating-a-google-api-service-account)
 * [Contributing](#contributing)
 * [License](#license)
-
-## Important Links for Programming Google Sheets
-
-### General API Documentation
-
-* [Google Sheets API Overview](https://developers.google.com/sheets/api)
-* [Google Sheets API Reference](https://developers.google.com/sheets/api/reference/rest)
-* [Batch Update Requests](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request)
-* [Discovery Document for the Sheets API](https://sheets.googleapis.com/$discovery/rest?version=v4)
-
-### Ruby Implementation of the Sheets API
-
-* [SheetsService Class](https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-sheets_v4/lib/google/apis/sheets_v4/service.rb)
-* [All Other Sheets Classes](https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-sheets_v4/lib/google/apis/sheets_v4/classes.rb)
-
-### Other Links
-
-* [Apps Script for Sheets](https://developers.google.com/apps-script/guides/sheets)
 
 ## Installation
 
@@ -53,6 +43,44 @@ If bundler is not being used to manage dependencies, install the gem by executin
 ```shell
 gem install sheets_v4
 ```
+
+## Important links for programming Google Sheets
+
+### General API documentation
+
+* [Google Sheets API Overview](https://developers.google.com/sheets/api)
+* [Google Sheets API Reference](https://developers.google.com/sheets/api/reference/rest)
+* [Batch Update Requests](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request)
+* [Discovery Document for the Sheets API](https://sheets.googleapis.com/$discovery/rest?version=v4)
+
+### Ruby implementation of the Sheets API
+
+* [SheetsService Class](https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-sheets_v4/lib/google/apis/sheets_v4/service.rb)
+* [All Other Sheets Classes](https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-sheets_v4/lib/google/apis/sheets_v4/classes.rb)
+
+### Other Links
+
+* [Apps Script for Sheets](https://developers.google.com/apps-script/guides/sheets)
+
+## Getting Started
+
+In order to use this gem, you will need to obtain a Google API sheets service
+credential following the instructions below.
+
+### Creating a Google Cloud project
+
+Create a Google Cloud project using [these directions](https://developers.google.com/workspace/guides/create-project).
+
+### Enable the APIs you want to use
+
+Enable the Sheets API for this project using [these directions](https://developers.google.com/workspace/guides/enable-apis).
+
+### Create a Google API credentials
+
+Create a service account and download credentials using [these directions](https://developers.google.com/workspace/guides/create-credentials#service-account).
+
+You can store the download credential files anywhere on your system. The recommended
+location is `~/.google-api-credential.json`.
 
 ## Usage
 
@@ -86,18 +114,164 @@ If the credential is stored elsewhere, pass the credential_source to `SheetsV4.s
 manually. `credential_source` can be a String:
 
 ```Ruby
-sheets_service = SheetsV4.sheets_service(credential_sourvce: File.read('credential.json'))
+sheets_service = SheetsV4.sheets_service(credential_source: File.read('credential.json'))
 ```
 
 an IO object:
 
 ```Ruby
 sheets_service = File.open('credential.json') do |credential_source|
-  SheetsV4.sheets_service(credential_sourvce:)
+  SheetsV4.sheets_service(credential_source:)
 end
 ```
 
 or an already constructed `Google::Auth::*`` object.
+
+### Building a request
+
+To use the Sheets API, you need to construct JSON formatted requests.
+
+These requests can be constructed using two different methods:
+1. constructing requests using `Google::Apis::SheetsV4::*` objects or
+2. constructing requests using hashes
+
+The following two sections show how each method can be used to construct
+a request to update a row of values in a sheet.
+
+For these two examples, values in the `values` array will be written to the
+sheet whose ID is 0. The values will be written one per row starting at cell A1.
+
+```Ruby
+values = %w[one two three four] # 'one' goes in A1, 'two' goes in A2, etc.
+```
+
+The method `SheetsService#batch_update_spreadsheet` will be used to write the values. This
+method takes a `batch_update_spreadsheet_request` object with a `update_cells` request
+that defines the update to perform.
+
+#### Method 1: constructing requests using `Google::Apis::SheetsV4::*` objects
+
+When using this method, keep the Ruby source file containing the SheetsService class
+([google/apis/sheets_v4/service.rb](https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-sheets_v4/lib/google/apis/sheets_v4/service.rb))
+and the Ruby source file containing the defitions of the request & data classes
+([lib/google/apis/sheets_v4/classes.rb](https://github.com/googleapis/google-api-ruby-client/blob/main/generated/google-apis-sheets_v4/lib/google/apis/sheets_v4/classes.rb))
+open for easy searching. These files will give you all the information you need
+to construct valid requests.
+
+Here is the example constructing requests using `Google::Apis::SheetsV4::*` objects
+
+```Ruby
+def values = %w[one two three four]
+
+def row_data(value)
+  Google::Apis::SheetsV4::RowData.new(
+    values: [
+      Google::Apis::SheetsV4::CellData.new(
+        user_entered_value:
+          Google::Apis::SheetsV4::ExtendedValue.new(string_value: value.to_s)
+      )
+    ]
+  )
+end
+
+def rows
+  values.map { |value| row_data(value) }
+end
+
+def write_values_request
+  fields = 'user_entered_value'
+  start = Google::Apis::SheetsV4::GridCoordinate.new(
+    sheet_id: 0, row_index: 0, column_index: 0
+  )
+  Google::Apis::SheetsV4::Request.new(
+    update_cells: Google::Apis::SheetsV4::UpdateCellsRequest.new(rows:, fields:, start:)
+  )
+end
+
+requests = Google::Apis::SheetsV4::BatchUpdateSpreadsheetRequest.new(requests: [write_values_request])
+
+spreadsheet_id = '18FAcgotK7nDfLTOTQuGCIjKwxkJMAguhn1OVzpFFgWY'
+SheetsV4.sheets_service.batch_update_spreadsheet(spreadsheet_id, requests)
+```
+
+#### Method 2: constructing requests using hashes
+
+When constructing requests using this method, keep the [Google Sheets Rest API Reference](https://developers.google.com/sheets/api/reference/rest)
+documentation open. In particular, [the Batch Update Requests page](https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/request#cutpasterequest)
+is particularly useful for building spreadsheet batch update requests.
+
+One caveat to keep in mind is that the Rest API documents object properties using
+Camel case BUT the Ruby API requires snake case.
+
+For instance, the Rest API documents the properties for a grid coordinate to be
+"sheetId", "rowIndex", and "columnIndex". However, in the Ruby API, you should
+construct this object using snake case:
+
+```Ruby
+grid_coordinate = { sheet_id: 0, row_index: 0, column_index: 0 }
+```
+
+Here is the example constructing requests using hashes:
+
+```Ruby
+def values = %w[one two three four]
+
+def rows
+  values.map do |value|
+    { values: [{ user_entered_value: { string_value: value } }] }
+  end
+end
+
+def write_values_request
+  fields = 'user_entered_value'
+  start = { sheet_id: 0, row_index: 0, column_index: 0 }
+  { update_cells: { rows:, fields:, start: } }
+end
+
+requests = { requests: [write_values_request] }
+
+spreadsheet_id = '18FAcgotK7nDfLTOTQuGCIjKwxkJMAguhn1OVzpFFgWY'
+response = SheetsV4.sheets_service.batch_update_spreadsheet(spreadsheet_id, requests)
+```
+
+#### Which method should be used?
+
+Either method will do the same job. I prefer "Method 2: constructing requests using
+hashes" because my code is more concise and easy to read.
+
+While either method can produce a malformed request, "Method 2" is more likely to
+result in malformed requests. Unfortunately, when given a malformed request, the
+Google Sheets API will do one of following depending on the nature of the problem:
+
+1. Raise a `Google::Apis::ClientError` with some additional information
+2. Raise a `Google::Apis::ClientError` with no additional information (this the most
+   common result)
+3. Not return an error with some of the batch requests not having the expected outcome
+
+Luckily, this library provides a way to validate that requests are valid and
+identifies precisely where the request objects do not conform to the API description.
+That is the subject of the next section [Validating requests](#validating-requests).
+
+### Validating requests
+
+The [`SheetsV4.validate_api_object`](https://rubydoc.info/gems/sheets_v4/SheetsV4#validate_api_object-class_method)
+method can be used to validate request objects prior to using them in the Google
+Sheets API.
+
+This method takes a `schema_name` and an `object` to validate. Schema names can be
+listed using [`SheetsV4.api_object_schema_names`](https://rubydoc.info/gems/sheets_v4/SheetsV4#api_object_schema_names-class_method).
+
+This method will either return `true` if `object` conforms to the schema OR it
+will raise a RuntimeError noting where the object structure did not conform to
+the schema.
+
+In the previous examples (see [Building a request](#building-a-request)), the
+following line can be inserted after the `requests =  ...` line to validate the
+request:
+
+```Ruby
+SheetsV4.validate_api_object(schema: 'batch_update_spreadsheet_request', object: requests)
+```
 
 ### Colors
 
@@ -114,8 +288,8 @@ SheetsV4::Color.black #=> {:red=>0.0, :green=>0.0, :blue=>0.0}
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run
-`rake spec` to run the tests. You can also run `bin/console` for an interactive
+After checking out the repo, run `bin/setup` to install dependencies and then, run
+`rake` to run the tests, static analysis, etc. You can also run `bin/console` for an interactive
 prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To
@@ -123,9 +297,6 @@ release a new version, update the version number in `version.rb`, and then run
 `bundle exec rake release`, which will create a git tag for the version, push git
 commits and the created tag, and push the `.gem` file to
 [rubygems.org](https://rubygems.org).
-
-## Creating a Google API Service Account
-
 
 ## Contributing
 

--- a/lib/sheets_v4.rb
+++ b/lib/sheets_v4.rb
@@ -19,12 +19,16 @@ module SheetsV4
   #
   # Simplifies creating and configuring a the credential.
   #
-  # @example using the crednetial in `~/.google-api-credential`
+  # @example using the credential in `~/.google-api-credential`
   #   SheetsV4.sheets_service
   #
   # @example using a credential passed in as a string
-  #   credential_source = File.read(File.join(Dir.home, '.credential'))
-  #   SheetsV4.sheets_service(credential_source:
+  #   credential_source = File.read(File.expand_path('~/.google-api-credential.json'))
+  #   SheetsV4.sheets_service(credential_source:)
+  #
+  # @example using a credential passed in as an IO
+  #   credential_source = File.open(File.expand_path('~/.google-api-credential.json'))
+  #   SheetsV4.sheets_service(credential_source:)
   #
   # @param credential_source [nil, String, IO, Google::Auth::*] may
   #   be either an already constructed credential, the credential read into a String or
@@ -50,10 +54,10 @@ module SheetsV4
   # Validate the object using the named JSON schema
   #
   # The JSON schemas are loaded from the Google Disocvery API. The schemas names are
-  # returned by `SheetsV4.api_object_schemas.keys`.
+  # returned by `SheetsV4.api_object_schema_names`.
   #
   # @example
-  #   schema_name = 'BatchUpdateSpreadsheetRequest'
+  #   schema_name = 'batch_update_spreadsheet_request'
   #   object = { 'requests' => [] }
   #   SheetsV4.validate_api_object(schema_name:, object:)
   #
@@ -67,6 +71,17 @@ module SheetsV4
   #
   def self.validate_api_object(schema_name:, object:, logger: Logger.new(nil))
     SheetsV4::ValidateApiObjects::Validate.new(logger:).call(schema_name:, object:)
+  end
+
+  # List the names of the schemas available to use in the Google Sheets API
+  #
+  # @example List the name of the schemas available
+  #   SheetsV4.api_object_schema_names #=> ["add_banding_request", "add_banding_response", ...]
+  #
+  # @return [Array<String>] the names of the schemas available
+  #
+  def self.api_object_schema_names(logger: Logger.new(nil))
+    SheetsV4::ValidateApiObjects::LoadSchemas.new(logger:).call.keys.sort
   end
 
   # Given the name of the color, return a Google Sheets API color object

--- a/spec/sheets_v4_spec.rb
+++ b/spec/sheets_v4_spec.rb
@@ -75,6 +75,29 @@ RSpec.describe SheetsV4 do
     end
   end
 
+  describe '.api_object_schema_names' do
+    subject { described_class.api_object_schema_names(logger:) }
+    let(:logger) { double('logger') }
+    let(:schema_loader) { double('schema_loader') }
+    let(:schemas) { double('schemas') }
+    let(:schema_names) { %w[schema1 schema2] }
+    let(:expected_result) { double('expected_result') }
+
+    before do
+      allow(SheetsV4::ValidateApiObjects::LoadSchemas).to(
+        receive(:new)
+        .with(logger:)
+        .and_return(schema_loader)
+      )
+      allow(schema_loader).to receive(:call).and_return(schemas)
+      allow(schemas).to receive(:keys).and_return(schema_names)
+    end
+
+    it 'should call SheetsV4::ValidateApiObjects::LoadSchemas to load the schemas' do
+      expect(subject).to eq(schema_names)
+    end
+  end
+
   describe '.color' do
     it 'should return the color object for the given name' do
       SheetsV4::Color::COLORS.each_key do |color_name|


### PR DESCRIPTION
Update documentation for how to:
* Get service account credentials
* Construct a request
* Validate a request

In adding this documentation, I realized I had forgotten to add the `SheetsV4.api_object_schema_names` method so I add that as well. While I was in sheets_v4.rb file, I also made some documentation corrections there as well.