### PR TITLE
Rename SheetsV4::CredentialCreator to SheetsV4::CreateCredential

### DIFF
--- a/lib/sheets_v4.rb
+++ b/lib/sheets_v4.rb
@@ -2,7 +2,7 @@
 
 require_relative 'sheets_v4/version'
 require_relative 'sheets_v4/color'
-require_relative 'sheets_v4/credential_creator'
+require_relative 'sheets_v4/create_credential'
 require_relative 'sheets_v4/validate_api_objects'
 
 require 'google/apis/sheets_v4'
@@ -42,7 +42,7 @@ module SheetsV4
   #
   # @return a new SheetsService instance
   #
-  def self.sheets_service(credential_source: nil, scopes: nil, credential_creator: SheetsV4::CredentialCreator)
+  def self.sheets_service(credential_source: nil, scopes: nil, credential_creator: SheetsV4::CreateCredential)
     credential_source ||= File.read(File.expand_path('~/.google-api-credential.json'))
     scopes ||= [Google::Apis::SheetsV4::AUTH_SPREADSHEETS]
 

--- a/lib/sheets_v4/color.rb
+++ b/lib/sheets_v4/color.rb
@@ -23,7 +23,6 @@ module SheetsV4
       #
       # @param method_name [#to_sym] the name of the color
       # @param arguments [Array] ignored
-      # @param block [Proc] ignored
       # @return [Hash] the color object
       # @api private
       def method_missing(method_name, *arguments, &)

--- a/lib/sheets_v4/create_credential.rb
+++ b/lib/sheets_v4/create_credential.rb
@@ -5,7 +5,7 @@ require 'json_schemer'
 module SheetsV4
   # Creates a Google API credential with an access token
   #
-  class CredentialCreator
+  class CreateCredential
     # Creates a Google API credential with an access token
     #
     # This wraps the boiler plate code into one function to make constructing a
@@ -14,7 +14,7 @@ module SheetsV4
     # @example Constructing a credential from the contents of ~/.credential
     #   credential_source = File.read(File.join(Dir.home, '.credential'))
     #   scope = Google::Apis::SheetsV4::AUTH_SPREADSHEETS
-    #   credential = GoogleApisHelpers.credential(credential_source, scope)
+    #   credential = SheetsV4::CreateCredential.call(credential_source, scope)
     #
     # @param [Google::Auth::*, String, IO, nil] credential_source may be one of four things:
     #   (1) a previously created credential that you want to reuse, (2) a credential read

--- a/lib/sheets_v4/validate_api_objects/load_schemas.rb
+++ b/lib/sheets_v4/validate_api_objects/load_schemas.rb
@@ -84,7 +84,7 @@ module SheetsV4
       # Log an error and raise a RuntimeError based on the HTTP response code
       # @param http_response [Net::HTTPResponse] the HTTP response
       # @return [void]
-      # @raises [RuntimeError]
+      # @raise [RuntimeError]
       # @api private
       def raise_error(http_response)
         message = "HTTP Error '#{http_response.code}' loading schemas from '#{http_response.uri}'"

--- a/lib/sheets_v4/validate_api_objects/resolve_schema_ref.rb
+++ b/lib/sheets_v4/validate_api_objects/resolve_schema_ref.rb
@@ -53,7 +53,7 @@ module SheetsV4
 
       # Resolve a JSON schema reference
       #
-      # @param ref [URI] the reference to resolve usually in the form "json-schemer://schema/{name}"
+      # @param ref [URI] the reference to resolve usually in the form "json-schemer://schema/[name]"
       #
       # @return [Hash] the schema object as a hash
       #

--- a/spec/sheets_v4/create_credential_spec.rb
+++ b/spec/sheets_v4/create_credential_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SheetsV4::CredentialCreator do
+RSpec.describe SheetsV4::CreateCredential do
   describe '.call' do
     subject { described_class.call(credential_source, scopes, credential_factory) }
 


### PR DESCRIPTION
Since `SheetsV4::CredentialCreator` is a Command pattern class, rename this class to `SheetsV4::CreateCredential` to follow the convention of using a verb-noun combination that clearly describes the action the performs on the object or the outcome it produces.