### PR TITLE
Rename SheetsV4::ValidateApiObjects::Validate to SheetsV4::ValidateApiObjects::ValidateApiObject

### DIFF
--- a/lib/sheets_v4.rb
+++ b/lib/sheets_v4.rb
@@ -70,7 +70,7 @@ module SheetsV4
   # @return [void]
   #
   def self.validate_api_object(schema_name:, object:, logger: Logger.new(nil))
-    SheetsV4::ValidateApiObjects::Validate.new(logger:).call(schema_name:, object:)
+    SheetsV4::ValidateApiObjects::ValidateApiObject.new(logger:).call(schema_name:, object:)
   end
 
   # List the names of the schemas available to use in the Google Sheets API

--- a/lib/sheets_v4/validate_api_objects.rb
+++ b/lib/sheets_v4/validate_api_objects.rb
@@ -17,4 +17,4 @@ end
 require_relative 'validate_api_objects/load_schemas'
 require_relative 'validate_api_objects/resolve_schema_ref'
 require_relative 'validate_api_objects/traverse_object_tree'
-require_relative 'validate_api_objects/validate'
+require_relative 'validate_api_objects/validate_api_object'

--- a/lib/sheets_v4/validate_api_objects/validate_api_object.rb
+++ b/lib/sheets_v4/validate_api_objects/validate_api_object.rb
@@ -9,7 +9,7 @@ module SheetsV4
     #
     # @api public
     #
-    class Validate
+    class ValidateApiObject
       # Create a new validator
       #
       # By default, a nil logger is used. This means that no messages are logged.

--- a/spec/sheets_v4/validate_api_objects/validate_api_object_spec.rb
+++ b/spec/sheets_v4/validate_api_objects/validate_api_object_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe SheetsV4::ValidateApiObjects::Validate do
+RSpec.describe SheetsV4::ValidateApiObjects::ValidateApiObject do
   let(:validator) { described_class.new(logger:) }
   let(:logger) { Logger.new($stdout, level: Logger::DEBUG) }
 

--- a/spec/sheets_v4_spec.rb
+++ b/spec/sheets_v4_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe SheetsV4 do
     let(:object) { double('object') }
     let(:logger) { double('logger') }
 
-    it 'should call SheetsV4::ValidateApiObjects::Validate to do the validation' do
-      expect(SheetsV4::ValidateApiObjects::Validate).to(
+    it 'should call SheetsV4::ValidateApiObjects::ValidateApiObject to do the validation' do
+      expect(SheetsV4::ValidateApiObjects::ValidateApiObject).to(
         receive(:new)
         .with(logger:)
         .and_call_original
       )
-      expect_any_instance_of(SheetsV4::ValidateApiObjects::Validate).to(
+      expect_any_instance_of(SheetsV4::ValidateApiObjects::ValidateApiObject).to(
         receive(:call)
         .with(schema_name:, object:)
       )


### PR DESCRIPTION
Since SheetsV4::ValidateApiObjects::Validate is a Command pattern class, rename this class from `Validate` to `ValidateApiObject` to follow the convention of using a verb-noun combination that clearly describes the action the performs on the object or the outcome it produces.