### PR TITLE
Add conversions bewteen Date/DateTime and spreadsheet values

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -46,3 +46,4 @@
 * [ ] Protected ranges
 * [ ] Resize a sheet
 * [ ] Retrying on error
+* [ ] Set a custom datetime or decimal format for a range [1](https://developers.google.com/sheets/api/samples/formatting#set_a_custom_datetime_or_decimal_format_for_a_range)

--- a/lib/sheets_v4.rb
+++ b/lib/sheets_v4.rb
@@ -2,9 +2,14 @@
 
 require_relative 'sheets_v4/version'
 require_relative 'sheets_v4/color'
+require_relative 'sheets_v4/convert_dates_and_times'
 require_relative 'sheets_v4/create_credential'
 require_relative 'sheets_v4/api_object_validation'
 
+require 'active_support'
+require 'active_support/values/time_zone'
+require 'active_support/core_ext/numeric/time'
+require 'active_support/core_ext/string/zones'
 require 'google/apis/sheets_v4'
 require 'json'
 require 'logger'
@@ -15,102 +20,221 @@ require 'net/http'
 # @api public
 #
 module SheetsV4
-  # Create a new Google::Apis::SheetsV4::SheetsService object
-  #
-  # Simplifies creating and configuring a the credential.
-  #
-  # @example using the credential in `~/.google-api-credential`
-  #   SheetsV4.sheets_service
-  #
-  # @example using a credential passed in as a string
-  #   credential_source = File.read(File.expand_path('~/.google-api-credential.json'))
-  #   SheetsV4.sheets_service(credential_source:)
-  #
-  # @example using a credential passed in as an IO
-  #   credential_source = File.open(File.expand_path('~/.google-api-credential.json'))
-  #   SheetsV4.sheets_service(credential_source:)
-  #
-  # @param credential_source [nil, String, IO, Google::Auth::*] may
-  #   be either an already constructed credential, the credential read into a String or
-  #   an open file with the credential ready to be read. Passing `nil` will result
-  #   in the credential being read from `~/.google-api-credential.json`.
-  #
-  # @param scopes [Object, Array] one or more scopes to access.
-  #
-  # @param credential_creator [#credential] Used to inject the credential creator for
-  #   testing.
-  #
-  # @return a new SheetsService instance
-  #
-  def self.sheets_service(credential_source: nil, scopes: nil, credential_creator: SheetsV4::CreateCredential)
-    credential_source ||= File.read(File.expand_path('~/.google-api-credential.json'))
-    scopes ||= [Google::Apis::SheetsV4::AUTH_SPREADSHEETS]
+  class << self
+    # Create a new Google::Apis::SheetsV4::SheetsService object
+    #
+    # Simplifies creating and configuring a the credential.
+    #
+    # @example using the credential in `~/.google-api-credential`
+    #   SheetsV4.sheets_service
+    #
+    # @example using a credential passed in as a string
+    #   credential_source = File.read(File.expand_path('~/.google-api-credential.json'))
+    #   SheetsV4.sheets_service(credential_source:)
+    #
+    # @example using a credential passed in as an IO
+    #   credential_source = File.open(File.expand_path('~/.google-api-credential.json'))
+    #   SheetsV4.sheets_service(credential_source:)
+    #
+    # @param credential_source [nil, String, IO, Google::Auth::*] may
+    #   be either an already constructed credential, the credential read into a String or
+    #   an open file with the credential ready to be read. Passing `nil` will result
+    #   in the credential being read from `~/.google-api-credential.json`.
+    #
+    # @param scopes [Object, Array] one or more scopes to access.
+    #
+    # @param credential_creator [#credential] Used to inject the credential creator for
+    #   testing.
+    #
+    # @return a new SheetsService instance
+    #
+    def sheets_service(credential_source: nil, scopes: nil, credential_creator: SheetsV4::CreateCredential)
+      credential_source ||= File.read(File.expand_path('~/.google-api-credential.json'))
+      scopes ||= [Google::Apis::SheetsV4::AUTH_SPREADSHEETS]
 
-    Google::Apis::SheetsV4::SheetsService.new.tap do |service|
-      service.authorization = credential_creator.call(credential_source, scopes)
+      Google::Apis::SheetsV4::SheetsService.new.tap do |service|
+        service.authorization = credential_creator.call(credential_source, scopes)
+      end
+    end
+
+    # Validate the object using the named JSON schema
+    #
+    # The JSON schemas are loaded from the Google Disocvery API. The schemas names are
+    # returned by `SheetsV4.api_object_schema_names`.
+    #
+    # @example
+    #   schema_name = 'batch_update_spreadsheet_request'
+    #   object = { 'requests' => [] }
+    #   SheetsV4.validate_api_object(schema_name:, object:)
+    #
+    # @param schema_name [String] the name of the schema to validate against
+    # @param object [Object] the object to validate
+    # @param logger [Logger] the logger to use for logging error, info, and debug message
+    #
+    # @raise [RuntimeError] if the object does not conform to the schema
+    #
+    # @return [void]
+    #
+    def validate_api_object(schema_name:, object:, logger: Logger.new(nil))
+      SheetsV4::ApiObjectValidation::ValidateApiObject.new(logger:).call(schema_name:, object:)
+    end
+
+    # List the names of the schemas available to use in the Google Sheets API
+    #
+    # @example List the name of the schemas available
+    #   SheetsV4.api_object_schema_names #=> ["add_banding_request", "add_banding_response", ...]
+    #
+    # @return [Array<String>] the names of the schemas available
+    #
+    def api_object_schema_names(logger: Logger.new(nil))
+      SheetsV4::ApiObjectValidation::LoadSchemas.new(logger:).call.keys.sort
+    end
+
+    # Given the name of the color, return a Google Sheets API color object
+    #
+    # Available color names are listed using `SheetsV4.color_names`.
+    #
+    # The object returned is frozen.  If you want a color you can change (for instance,
+    # to adjust the `alpha` attribute), you must clone the object returned.
+    #
+    # @example
+    #   SheetsV4::Color.color(:red) #=> { "red": 1.0, "green": 0.0, "blue": 0.0 }
+    #
+    # @param name [#to_sym] the name of the color requested
+    #
+    # @return [Hash] The color requested e.g. `{ "red": 1.0, "green": 0.0, "blue": 0.0 }`
+    #
+    def color(name)
+      SheetsV4::Color::COLORS[name.to_sym] || raise("Color #{name} not found")
+    end
+
+    # List the names of the colors available to use in the Google Sheets API
+    #
+    # @example
+    #   SheetsV4::Color.color_names #=> [:black, :white, :red, :green, :blue, :yellow, :magenta, :cyan, ...]
+    #
+    # @return [Array<Symbol>] the names of the colors available
+    #
+    def color_names = SheetsV4::Color::COLORS.keys
+
+    # @!attribute [rw] default_spreadsheet_tz
+    #
+    # Set the default time zone for date and time conversions
+    #
+    # Valid time zone names are those listed in one of these two sources:
+    # * `ActiveSupport::TimeZone.all.map { |tz| tz.tzinfo.name }`
+    # * `ActiveSupport::TimeZone.all.map(&:name)`
+    #
+    # If you want to set the timezone to the time zone of the system's local time,
+    # you could use the [timezone_local gem](https://rubygems.org/gems/timezone_local).
+    #
+    # @example
+    #   SheetsV4.default_spreadsheet_tz = 'America/Los_Angeles'
+    #
+    # @example Set the time zone to the system's local time
+    #   require 'timezone_local'
+    #   SheetsV4.default_spreadsheet_tz = TimeZone::Local.get.name
+    #
+    # @return [void]
+    #
+    def default_spreadsheet_tz
+      @default_spreadsheet_tz || raise('default_spreadsheet_tz not set')
+    end
+
+    def default_spreadsheet_tz=(time_zone)
+      raise "Invalid time zone '#{time_zone}'" unless ActiveSupport::TimeZone.new(time_zone)
+
+      @default_date_and_time_converter = nil unless @default_spreadsheet_tz == time_zone
+      @default_spreadsheet_tz = time_zone
+    end
+
+    # The default converter for dates and times
+    # @return [SheetsV4::ConvertDatesAndTimes]
+    # @api private
+    def default_date_and_time_converter
+      @default_date_and_time_converter ||= SheetsV4::ConvertDatesAndTimes.new(default_spreadsheet_tz)
+    end
+
+    # Convert a Ruby Date object to a Google Sheet date value
+    #
+    # Uses the time zone given by `SheetsV4.default_spreadsheet_tz`.
+    #
+    # @example with a Date object
+    #   SheetsV4.default_spreadsheet_tz = 'America/Los_Angeles'
+    #   date = Date.parse('2021-05-17')
+    #   SheetsV4.date_to_gs(date) #=> 44333
+    #
+    # @example with a DateTime object
+    #   SheetsV4.default_spreadsheet_tz = 'America/Los_Angeles'
+    #   date_time = DateTime.parse('2021-05-17 11:36:00 UTC')
+    #   SheetsV4.date_to_gs(date_time) #=> 44333
+    #
+    # @param date [DateTime, Date, nil] the date to convert
+    #
+    # @return [Float, String] the value to sstore in a Google Sheet cell
+    #   Returns a Float if date is not nil; otherwise, returns an empty string
+    #
+    def date_to_gs(date)
+      default_date_and_time_converter.date_to_gs(date)
+    end
+
+    # Convert a Google Sheets date value to a Ruby Date object
+    #
+    # @example with a date value
+    #   SheetsV4.default_spreadsheet_tz = 'America/Los_Angeles'
+    #   gs_value = 44333
+    #   SheetsV4.gs_to_date(gs_value) #=> #<Date: 2021-05-17 ...>
+    #
+    # @example with a date and time value
+    #   SheetsV4.default_spreadsheet_tz = 'America/Los_Angeles'
+    #   gs_value = 44333.191666666666
+    #   SheetsV4.gs_to_date(gs_value) #=> #<Date: 2021-05-17 ...>
+    #
+    # @param gs_value [Float, "", nil] the value from the Google Sheets cell
+    #
+    # @return [Date, nil] the value represented by gs_date
+    #
+    #   Returns a Date object if a Float was given; otherwise, returns nil if an
+    #   empty string or nil was given.
+    #
+    def gs_to_date(gs_value)
+      default_date_and_time_converter.gs_to_date(gs_value)
+    end
+
+    # Convert a Ruby DateTime object to a Google Sheets value
+    #
+    # @example
+    #   SheetsV4.default_spreadsheet_tz = 'America/Los_Angeles'
+    #   date_time = DateTime.parse('2021-05-17 11:36:00 UTC')
+    #   SheetsV4.datetime_to_gs(date_time) #=> 44333.191666666666
+    #
+    # @param datetime [DateTime, nil] the date and time to convert
+    #
+    # @return [Float, String] the value to store in a Google Sheet cell
+    #   Returns a Float if datetime is not nil; otherwise, returns an empty string.
+    #
+    def datetime_to_gs(datetime)
+      default_date_and_time_converter.datetime_to_gs(datetime)
+    end
+
+    # Convert a Google Sheets date time value to a DateTime object
+    #
+    # Time is rounded to the nearest second. The DateTime object returned is in
+    # the time zone given by `SheetsV4.default_spreadsheet_tz`.
+    #
+    # @example
+    #   SheetsV4.default_spreadsheet_tz = 'America/Los_Angeles'
+    #   gs_value = 44333.191666666666
+    #   SheetsV4.gs_to_datetime(gs_value) #=> #<DateTime: 2021-05-17T04:35:59-07:00 ...>
+    #
+    # @param gs_value [Float, "", nil] the value from the Google Sheets cell
+    #
+    # @return [DateTime, nil] the value represented by gs_datetime
+    #   Returns a DateTime object if a Float was given; otherwise, returns nil if an
+    #   empty string or nil was given.
+    #
+    def gs_to_datetime(gs_value)
+      default_date_and_time_converter.gs_to_datetime(gs_value)
     end
   end
-
-  # Validate the object using the named JSON schema
-  #
-  # The JSON schemas are loaded from the Google Disocvery API. The schemas names are
-  # returned by `SheetsV4.api_object_schema_names`.
-  #
-  # @example
-  #   schema_name = 'batch_update_spreadsheet_request'
-  #   object = { 'requests' => [] }
-  #   SheetsV4.validate_api_object(schema_name:, object:)
-  #
-  # @param schema_name [String] the name of the schema to validate against
-  # @param object [Object] the object to validate
-  # @param logger [Logger] the logger to use for logging error, info, and debug message
-  #
-  # @raise [RuntimeError] if the object does not conform to the schema
-  #
-  # @return [void]
-  #
-  def self.validate_api_object(schema_name:, object:, logger: Logger.new(nil))
-    SheetsV4::ApiObjectValidation::ValidateApiObject.new(logger:).call(schema_name:, object:)
-  end
-
-  # List the names of the schemas available to use in the Google Sheets API
-  #
-  # @example List the name of the schemas available
-  #   SheetsV4.api_object_schema_names #=> ["add_banding_request", "add_banding_response", ...]
-  #
-  # @return [Array<String>] the names of the schemas available
-  #
-  def self.api_object_schema_names(logger: Logger.new(nil))
-    SheetsV4::ApiObjectValidation::LoadSchemas.new(logger:).call.keys.sort
-  end
-
-  # Given the name of the color, return a Google Sheets API color object
-  #
-  # Available color names are listed using `SheetsV4.color_names`.
-  #
-  # The object returned is frozen.  If you want a color you can change (for instance,
-  # to adjust the `alpha` attribute), you must clone the object returned.
-  #
-  # @example
-  #   SheetsV4::Color.color(:red) #=> { "red": 1.0, "green": 0.0, "blue": 0.0 }
-  #
-  # @param name [#to_sym] the name of the color requested
-  #
-  # @return [Hash] The color requested e.g. `{ "red": 1.0, "green": 0.0, "blue": 0.0 }`
-  #
-  # @api public
-  #
-  def self.color(name)
-    SheetsV4::Color::COLORS[name.to_sym] || raise("Color #{name} not found")
-  end
-
-  # List the names of the colors available to use in the Google Sheets API
-  #
-  # @example
-  #   SheetsV4::Color.color_names #=> [:black, :white, :red, :green, :blue, :yellow, :magenta, :cyan, ...]
-  #
-  # @return [Array<Symbol>] the names of the colors available
-  # @api public
-  #
-  def self.color_names = SheetsV4::Color::COLORS.keys
 end

--- a/lib/sheets_v4/api_object_validation/validate_api_object.rb
+++ b/lib/sheets_v4/api_object_validation/validate_api_object.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/inflector'
 require 'json_schemer'
 

--- a/lib/sheets_v4/convert_dates_and_times.rb
+++ b/lib/sheets_v4/convert_dates_and_times.rb
@@ -1,0 +1,243 @@
+# Copyright (c) 2023 Yahoo
+
+# frozen_string_literal: true
+
+require 'active_support'
+require 'active_support/values/time_zone'
+require 'active_support/core_ext/numeric/time'
+require 'active_support/core_ext/string/zones'
+
+module SheetsV4
+  # Convert between Ruby Date and DateTime objects and Google Sheets values
+  #
+  # Google Sheets uses decimal values to represent dates and times. These
+  # conversion routines allows converting from Ruby Date and DateTime objects
+  # and values that Google Sheets recognize.
+  #
+  # DateTime objects passed to `datetime_to_gs` or `date_to_gs` are converted to
+  # the time zone of the spreadsheet given in the initializer. DateTime objects
+  # returned by `gs_to_datetime` are always in the spreadsheet's time zone.
+  #
+  # Valid time zone names are those listed in one of these two sources:
+  # * `ActiveSupport::TimeZone.all.map { |tz| tz.tzinfo.name }`
+  # * `ActiveSupport::TimeZone.all.map(&:name)`
+  #
+  # @example
+  #   tz = spreadsheet.properties.time_zone #=> e.g. 'America/Los_Angeles'
+  #   converter = SheetsV4::ConvertDatesAndTimes.new(tz)
+  #   date = Date.parse('1967-03-15')
+  #   converter.date_to_gs(date) #=> 24546
+  #   converter.gs_to_date(24546) #=> #<Date: 1967-03-15 ((2439565j,0s,0n),+0s,2299161j)>
+  #
+  #   date_time = DateTime.parse('2021-05-17 11:36:00 UTC')
+  #   converter.datetime_to_gs(date_time) #=> 44333.191666666666
+  #   converter.gs_to_datetime(44333.191666666666)
+  #   #=> #<DateTime: 2021-05-17T11:36:00+00:00 ((2459352j,41760s,0n),+0s,2299161j)>
+  #
+  # @api public
+  #
+  class ConvertDatesAndTimes
+    # The time zone passed into the initializer
+    #
+    # @example
+    #   time_zone = 'UTC'
+    #   converter = SheetsV4::ConvertDatesAndTimes.new(time_zone)
+    #   converter.spreadsheet_tz
+    #   #=> #<ActiveSupport::TimeZone:0x00007fe39000f908 @name="America/Los_Angeles", ...>
+    #
+    # @return [ActiveSupport::TimeZone] the time zone
+    #
+    attr_reader :spreadsheet_tz
+
+    # Initialize the conversion routines for a spreadsheet
+    #
+    # @example
+    #   time_zone = 'America/Los_Angeles'
+    #   converter = SheetsV4::ConvertDatesAndTimes.new(time_zone)
+    #
+    # @param spreadsheet_tz [String] the time zone set in the spreadsheet properties
+    #
+    # @raise [RuntimeError] if the time zone is not valid
+    #
+    def initialize(spreadsheet_tz)
+      @spreadsheet_tz = ActiveSupport::TimeZone.new(spreadsheet_tz)
+      raise "Invalid time zone '#{spreadsheet_tz}'" unless @spreadsheet_tz
+    end
+
+    # Convert a Ruby DateTime object to a Google Sheets date time value
+    #
+    # @example
+    #   time_zone = 'America/Los_Angeles'
+    #   converter = SheetsV4::ConvertDatesAndTimes.new(time_zone)
+    #   date_time = DateTime.parse('2021-05-17 11:36:00 UTC')
+    #   converter.datetime_to_gs(date_time) #=> 44333.191666666666
+    #
+    # @param datetime [DateTime, nil] the date and time to convert
+    #
+    # @return [Float, String] the value to store in a Google Sheets cell
+    #   Returns a Float if datetime is not nil; otherwise, returns an empty string.
+    #
+    def datetime_to_gs(datetime)
+      return '' unless datetime
+
+      time = datetime.to_time.in_time_zone(spreadsheet_tz)
+      unix_to_gs_epoch(replace_time_zone(time, 'UTC').to_i)
+    end
+
+    # Convert a Google Sheets date time value to a DateTime object
+    #
+    # Time is rounded to the nearest second. The DateTime object returned is in
+    # the spreadsheet's time zone given in the initiaizer.
+    #
+    # @example
+    #   time_zone = 'America/Los_Angeles'
+    #   converter = SheetsV4::ConvertDatesAndTimes.new(time_zone)
+    #   gs_value = 44333.191666666666
+    #   converter.gs_to_datetime(gs_value) #=> #<DateTime: 2021-05-17T04:35:59-07:00 ...>
+    #
+    # @param gs_datetime [Float, "", nil] the value from the Google Sheets cell
+    #
+    # @return [DateTime, nil] the value represented by gs_datetime
+    #   Returns a DateTime object if a Float was given; otherwise, returns nil if an
+    #   empty string or nil was given.
+    #
+    def gs_to_datetime(gs_datetime)
+      return nil if gs_datetime.nil? || gs_datetime == ''
+
+      raise 'gs_datetime is a string' if gs_datetime.is_a?(String)
+
+      unix_epoch_datetime = gs_to_unix_epoch(gs_datetime.to_f)
+      time = Time.at_without_coercion(unix_epoch_datetime, in: 'UTC')
+      replace_time_zone(time, spreadsheet_tz).to_datetime
+    end
+
+    # Convert a Ruby Date object to a Google Sheets date value
+    #
+    # The Google Sheets date value is a float.
+    #
+    # @example with a Date object
+    #   time_zone = 'America/Los_Angeles'
+    #   converter = SheetsV4::ConvertDatesAndTimes.new(time_zone)
+    #   date = Date.parse('2021-05-17')
+    #   converter.date_to_gs(date) #=> 44333
+    #
+    # @example with a DateTime object
+    #   time_zone = 'America/Los_Angeles'
+    #   converter = SheetsV4::ConvertDatesAndTimes.new(time_zone)
+    #   date_time = DateTime.parse('2021-05-17 11:36:00 UTC')
+    #   converter.date_to_gs(date_time) #=> 44333
+    #
+    # @param date [DateTime, Date, nil] the date to convert
+    #
+    # @return [Float, String] the value to sstore in a Google Sheets cell
+    #   Returns a Float if date is not nil; otherwise, returns an empty string
+    #
+    def date_to_gs(date)
+      return datetime_to_gs(date).to_i if date.is_a?(DateTime)
+
+      return (date - gs_epoch_start_date).to_i if date.is_a?(Date)
+
+      ''
+    end
+
+    # Convert a Google Sheets date value to a Ruby Date object
+    #
+    # @example with a Date value
+    #   time_zone = 'America/Los_Angeles'
+    #   converter = SheetsV4::ConvertDatesAndTimes.new(time_zone)
+    #   gs_value = 44333
+    #   converter.gs_to_date(gs_value) #=> #<Date: 2021-05-17 ...>
+    #
+    # @example with a Date and Time value
+    #   time_zone = 'America/Los_Angeles'
+    #   converter = SheetsV4::ConvertDatesAndTimes.new(time_zone)
+    #   gs_value = 44333.191666666666
+    #   converter.gs_to_date(gs_value) #=> #<Date: 2021-05-17 ...>
+    #
+    # @param gs_date [Float, "", nil] the value from the Google Sheets cell
+    #
+    # @return [Date, nil] the value represented by gs_date
+    #   Returns a Date object if a Float was given; otherwise, returns nil if an
+    #   empty string or nil was given.
+    #
+    def gs_to_date(gs_date)
+      return nil if gs_date.nil? || gs_date == ''
+
+      raise 'gs_date is a string' if gs_date.is_a?(String)
+
+      (gs_epoch_start_date + gs_date.to_i)
+    end
+
+    private
+
+    # The Google Sheets epoch start Date to use when calculating dates
+    # @return [Date] the 'zero' Date
+    # @api private
+    def gs_epoch_start_date
+      @gs_epoch_start_date ||= Date.parse('1899-12-30')
+    end
+
+    # The number of seconds in a day
+    #
+    # @return [Integer] number of seconds in a day
+    #
+    SECONDS_PER_DAY = 86_400
+
+    # The number of seconds between the Google Sheets Epoch and Unix Epoch
+    #
+    # Effectively the number of seconds between 1899-12-30 00:00:00 UTC and
+    # 1970-01-01 00:00:00 UTC.
+    #
+    # @return [Integer] the number of seconds
+    #
+    SECONDS_BETWEEN_GS_AND_UNIX_EPOCHS = 25_569 * 86_400
+
+    # Convert a gs_datetime to unix time
+    #
+    # @param gs_datetime [Float] time relative to the Google Sheets Epoch
+    #
+    # gs_datetime is a float representing the number of days since the start of
+    # the Google Sheets epoch (1899-12-30 00:00:00 UTC).
+    #
+    # @return [Integer] the same datetime in Unix Time rounded to the nearest second
+    #
+    # Unix time is an integer representing the number of seconds since the start of
+    # the Unix Epoch (1970-01-01 00:00:00 UTC). The number returned is rounded
+    # to the nearest second.
+    #
+    # @api private
+    #
+    def gs_to_unix_epoch(gs_datetime)
+      (gs_datetime * SECONDS_PER_DAY).round - SECONDS_BETWEEN_GS_AND_UNIX_EPOCHS
+    end
+
+    # Convert a unix time to gs_datetime
+    #
+    # @param unix_time [Integer] seconds since the Unix epoch 1970-01-01 00:00:00 UTC
+    #
+    # @return [Float] days since the Google Sheets epoch 1899-12-30 00:00:00 UTC
+    #
+    # @api private
+    #
+    def unix_to_gs_epoch(unix_time)
+      (unix_time + SECONDS_BETWEEN_GS_AND_UNIX_EPOCHS).to_f / SECONDS_PER_DAY
+    end
+
+    # Given a time, change the time zone without impacting the displayed date/time
+    #
+    # @example
+    #   replace_time_zone(Time.parse('2021-05-21 11:40 UTC'), 'America/Los_Angeles')
+    #   #=> '2021-05-21 11:40 -0700'
+    #
+    # @param time [Time] the time object to adjust
+    # @param time_zone_name [String] the desired time zone
+    #
+    # @return [Time] the resulting time object
+    #
+    # @api private
+    #
+    def replace_time_zone(time, time_zone_name)
+      time.asctime.in_time_zone(time_zone_name)
+    end
+  end
+end

--- a/lib/sheets_v4/validate_api_objects/validate_api_object.rb
+++ b/lib/sheets_v4/validate_api_objects/validate_api_object.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/inflector'
 require 'json_schemer'
 

--- a/spec/sheets_v4/convert_dates_and_times_spec.rb
+++ b/spec/sheets_v4/convert_dates_and_times_spec.rb
@@ -1,0 +1,613 @@
+# Copyright (c) 2023 Yahoo
+# frozen_string_literal: true
+
+require 'yaml'
+
+require 'date'
+require 'active_support'
+require 'active_support/core_ext/time'
+
+RSpec.describe SheetsV4::ConvertDatesAndTimes do
+  let(:converter) { described_class.new(time_zone_name) }
+  let(:tolerance) { 0.00000001 }
+
+  context 'with an invalid time zone' do
+    let(:time_zone_name) { 'bogus time zone' }
+    it 'should raise an error' do
+      expect { converter }.to raise_error(RuntimeError)
+    end
+  end
+
+  context 'when the spreadsheet has the America/Los_Angeles time zone' do
+    let(:time_zone_name) { 'America/Los_Angeles' }
+    # let(:time_zone) { ActiveSupport::TimeZone.new(time_zone_name) }
+
+    it 'should not raise an error' do
+      expect { converter }.not_to raise_error
+    end
+
+    describe '#datetime_to_gs' do
+      subject { converter.datetime_to_gs(date_time) }
+      context 'with nil' do
+        let(:date_time) { nil }
+        it 'should return an empty string' do
+          expect(subject).to eq('')
+        end
+      end
+
+      context 'with DateTime 2021-05-17 18:36:00 UTC' do
+        let(:date_time) { DateTime.parse('2021-05-17 18:36:00 UTC') }
+        let(:expected_value) { 44_333.48333333 }
+
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'with DateTime 2021-05-17 11:36:00-0700' do
+        let(:date_time) { DateTime.parse('2021-05-17 11:36:00-0700') }
+        let(:expected_value) { 44_333.48333333 }
+
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'with DateTime 2021-01-01 11:22:33 UTC' do
+        let(:date_time) { DateTime.parse('2021-01-01 11:22:33 UTC') }
+        let(:expected_value) { 44_197.14065972 }
+
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+    end
+
+    describe '#date_to_gs' do
+      subject { converter.date_to_gs(date) }
+
+      context 'with nil' do
+        let(:date) { nil }
+        it 'should return an empty string' do
+          expect(subject).to eq('')
+        end
+      end
+
+      context 'with a Date 2021-05-18' do
+        let(:date) { Date.parse('2021-05-18') }
+        let(:expected_value) { 44_334.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-05-18 01:00:00 UTC' do
+        let(:date) { DateTime.parse('2021-05-18 01:00:00 UTC') }
+        let(:expected_value) { 44_333.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-05-18 23:00:00 UTC' do
+        let(:date) { DateTime.parse('2021-05-18 23:00:00 UTC') }
+        let(:expected_value) { 44_334.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-01-01 23:59:59-0800' do
+        let(:date) { DateTime.parse('2021-01-01 23:59:59-0800') }
+        let(:expected_value) { 44_197.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-01-01 00:00:01-0800' do
+        let(:date) { DateTime.parse('2021-01-01 00:00:01-0800') }
+        let(:expected_value) { 44_197.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-06-01 23:59:59-0700' do
+        let(:date) { DateTime.parse('2021-06-01 23:59:59-0700') }
+        let(:expected_value) { 44_348.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-06-01 00:00:01-0700' do
+        let(:date) { DateTime.parse('2021-06-01 00:00:01-0700') }
+        let(:expected_value) { 44_348.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+    end
+
+    describe '#gs_to_datetime' do
+      subject { converter.gs_to_datetime(gs_datetime_value) }
+      let(:tolerance) { 0.001 }
+
+      let(:expected_value) do
+        ActiveSupport::TimeZone.new(time_zone_name).parse(formatted_cell_value).to_datetime
+      end
+
+      context 'when gs_datetime_value is nil' do
+        let(:gs_datetime_value) { nil }
+        it 'should return nil' do
+          expect(subject).to eq(nil)
+        end
+      end
+      context 'when gs_datetime_value is an empty string' do
+        let(:gs_datetime_value) { '' }
+        it 'should return nil' do
+          expect(subject).to eq(nil)
+        end
+      end
+      context 'when the cell displays "2021-05-18 01:00:00"' do
+        let(:gs_datetime_value) { 44_334.04166667 }
+        let(:formatted_cell_value) { '2021-05-18 01:00:00' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(-7.0 / 24)
+        end
+      end
+
+      context 'when the cell displays "2021-05-18 23:00:00"' do
+        let(:gs_datetime_value) { 44_334.95833333 }
+        let(:formatted_cell_value) { '2021-05-18 23:00:00' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(-7.0 / 24)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01 23:59:59"' do
+        let(:gs_datetime_value) { 44_197.99998843 }
+        let(:formatted_cell_value) { '2021-01-01 23:59:59' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(-8.0 / 24)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01 00:00:01"' do
+        let(:gs_datetime_value) { 44_197.00001157 }
+        let(:formatted_cell_value) { '2021-01-01 00:00:01' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(-8.0 / 24)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01 23:59:59"' do
+        let(:gs_datetime_value) { 44_348.99998843 }
+        let(:formatted_cell_value) { '2021-06-01 23:59:59' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(-7.0 / 24)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01 00:00:01"' do
+        let(:gs_datetime_value) { 44_348.00001157 }
+        let(:formatted_cell_value) { '2021-06-01 00:00:01' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(-7.0 / 24)
+        end
+      end
+    end
+
+    describe '#gs_to_date' do
+      subject { converter.gs_to_date(gs_date_value) }
+      let(:tolerance) { 0.001 }
+
+      let(:expected_value) do
+        ActiveSupport::TimeZone.new(time_zone_name).parse(formatted_cell_value).to_date
+      end
+
+      context 'when gs_date_value is nil' do
+        let(:gs_date_value) { nil }
+        it 'should return nil' do
+          expect(subject).to eq(nil)
+        end
+      end
+
+      context 'when gs_date_value is an empty string' do
+        let(:gs_date_value) { '' }
+        it 'should return nil' do
+          expect(subject).to eq(nil)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01"' do
+        let(:gs_date_value) { 44_348.00000000 }
+        let(:formatted_cell_value) { '2021-06-01' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01"' do
+        let(:gs_date_value) { 44_197.00000000 }
+        let(:formatted_cell_value) { '2021-01-01' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-05-18 01:00:00"' do
+        let(:gs_date_value) { 44_334.04166667 }
+        let(:formatted_cell_value) { '2021-05-18 01:00:00' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-05-18 23:00:00"' do
+        let(:gs_date_value) { 44_334.95833333 }
+        let(:formatted_cell_value) { '2021-05-18 23:00:00' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01 23:59:59"' do
+        let(:gs_date_value) { 44_197.99998843 }
+        let(:formatted_cell_value) { '2021-01-01 23:59:59' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01 00:00:01"' do
+        let(:gs_date_value) { 44_197.00001157 }
+        let(:formatted_cell_value) { '2021-01-01 00:00:01' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01 23:59:59"' do
+        let(:gs_date_value) { 44_348.99998843 }
+        let(:formatted_cell_value) { '2021-06-01 23:59:59' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01 00:00:01"' do
+        let(:gs_date_value) { 44_348.00001157 }
+        let(:formatted_cell_value) { '2021-06-01 00:00:01' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+    end
+  end
+
+  context 'when the spreadsheet has the UTC time zone' do
+    let(:time_zone_name) { 'Etc/GMT' }
+    it 'should not raise an error' do
+      expect { converter }.not_to raise_error
+    end
+
+    describe '#datetime_to_gs' do
+      subject { converter.datetime_to_gs(date_time) }
+
+      context 'with nil' do
+        let(:date_time) { nil }
+        it 'should return an empty string' do
+          expect(subject).to eq('')
+        end
+      end
+
+      context 'with DateTime 2021-05-17 18:36:00 UTC' do
+        let(:date_time) { DateTime.parse('2021-05-18 1:00:00 UTC') }
+        let(:expected_value) { 44_334.04166667 }
+
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'with DateTime 2021-05-17 11:36:00-0700' do
+        let(:date_time) { DateTime.parse('2021-05-17 11:36:00-0700') }
+        let(:expected_value) { 44_333.77500000 }
+
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'with DateTime 2021-01-01 11:22:33 UTC' do
+        let(:date_time) { DateTime.parse('2021-01-01 0:00:01 UTC') }
+        let(:expected_value) { 44_197.00001157 }
+
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+    end
+
+    describe '#date_to_gs' do
+      subject { converter.date_to_gs(date) }
+
+      context 'with nil' do
+        let(:date) { nil }
+        it 'should return an empty string' do
+          expect(subject).to eq('')
+        end
+      end
+
+      context 'with a Date 2021-05-18' do
+        let(:date) { Date.parse('2021-05-18') }
+        let(:expected_value) { 44_334.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-05-18 01:00:00 UTC' do
+        let(:date) { DateTime.parse('2021-05-18 01:00:00 UTC') }
+        let(:expected_value) { 44_334.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-05-18 23:00:00 UTC' do
+        let(:date) { DateTime.parse('2021-05-18 23:00:00 UTC') }
+        let(:expected_value) { 44_334.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-01-01 23:59:59-0800' do
+        let(:date) { DateTime.parse('2021-01-01 23:59:59-0800') }
+        let(:expected_value) { 44_198.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-01-01 00:00:01-0800' do
+        let(:date) { DateTime.parse('2021-01-01 00:00:01-0800') }
+        let(:expected_value) { 44_197.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-06-01 23:59:59-0700' do
+        let(:date) { DateTime.parse('2021-06-01 23:59:59-0700') }
+        let(:expected_value) { 44_349.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+
+      context 'when a DateTime 2021-06-01 00:00:01-0700' do
+        let(:date) { DateTime.parse('2021-06-01 00:00:01-0700') }
+        let(:expected_value) { 44_348.00000000 }
+        it 'should return the expected value' do
+          expect(subject).to be_within(tolerance).of(expected_value)
+        end
+      end
+    end
+
+    describe '#gs_to_datetime' do
+      subject { converter.gs_to_datetime(gs_datetime_value) }
+      let(:tolerance) { 0.001 }
+
+      let(:expected_value) do
+        ActiveSupport::TimeZone.new(time_zone_name).parse(formatted_cell_value).to_datetime
+      end
+
+      context 'when gs_datetime_value is nil' do
+        let(:gs_datetime_value) { nil }
+        it 'should return nil' do
+          expect(subject).to eq(nil)
+        end
+      end
+
+      context 'when gs_datetime_value is an empty string' do
+        let(:gs_datetime_value) { '' }
+        it 'should return nil' do
+          expect(subject).to eq(nil)
+        end
+      end
+
+      context 'when gs_datetime_value is a string other than an empty string' do
+        let(:gs_datetime_value) { 'bogus string' }
+        it 'should raise an error' do
+          expect { subject }.to raise_error(RuntimeError)
+        end
+      end
+
+      context 'when the cell displays "2021-05-18 01:00:00"' do
+        let(:gs_datetime_value) { 44_334.04166667 }
+        let(:formatted_cell_value) { '2021-05-18 01:00:00' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(0)
+        end
+      end
+
+      context 'when the cell displays "2021-05-18 23:00:00"' do
+        let(:gs_datetime_value) { 44_334.95833333 }
+        let(:formatted_cell_value) { '2021-05-18 23:00:00' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(0)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01 23:59:59"' do
+        let(:gs_datetime_value) { 44_197.99998843 }
+        let(:formatted_cell_value) { '2021-01-01 23:59:59' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(0)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01 00:00:01"' do
+        let(:gs_datetime_value) { 44_197.00001157 }
+        let(:formatted_cell_value) { '2021-01-01 00:00:01' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(0)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01 23:59:59"' do
+        let(:gs_datetime_value) { 44_348.99998843 }
+        let(:formatted_cell_value) { '2021-06-01 23:59:59' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(0)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01 00:00:01"' do
+        let(:gs_datetime_value) { 44_348.00001157 }
+        let(:formatted_cell_value) { '2021-06-01 00:00:01' }
+        it 'should return the expected DateTime' do
+          expect(subject).to be_kind_of(DateTime)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+          expect(subject.offset).to eq(0)
+        end
+      end
+    end
+
+    describe '#gs_to_date' do
+      subject { converter.gs_to_date(gs_date_value) }
+      let(:tolerance) { 0.001 }
+
+      let(:expected_value) do
+        ActiveSupport::TimeZone.new(time_zone_name).parse(formatted_cell_value).to_date
+      end
+
+      context 'when gs_date_value is nil' do
+        let(:gs_date_value) { nil }
+        it 'should return nil' do
+          expect(subject).to eq(nil)
+        end
+      end
+
+      context 'when gs_date_value is an empty string' do
+        let(:gs_date_value) { '' }
+        it 'should return nil' do
+          expect(subject).to eq(nil)
+        end
+      end
+
+      context 'when gs_date_value is a string other than an empty string' do
+        let(:gs_date_value) { 'bogus string' }
+        it 'should raise an error' do
+          expect { subject }.to raise_error(RuntimeError)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01"' do
+        let(:gs_date_value) { 44_348.00000000 }
+        let(:formatted_cell_value) { '2021-06-01' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01"' do
+        let(:gs_date_value) { 44_197.00000000 }
+        let(:formatted_cell_value) { '2021-01-01' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-05-18 01:00:00"' do
+        let(:gs_date_value) { 44_334.04166667 }
+        let(:formatted_cell_value) { '2021-05-18 01:00:00' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-05-18 23:00:00"' do
+        let(:gs_date_value) { 44_334.95833333 }
+        let(:formatted_cell_value) { '2021-05-18 23:00:00' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01 23:59:59"' do
+        let(:gs_date_value) { 44_197.99998843 }
+        let(:formatted_cell_value) { '2021-01-01 23:59:59' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-01-01 00:00:01"' do
+        let(:gs_date_value) { 44_197.00001157 }
+        let(:formatted_cell_value) { '2021-01-01 00:00:01' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01 23:59:59"' do
+        let(:gs_date_value) { 44_348.99998843 }
+        let(:formatted_cell_value) { '2021-06-01 23:59:59' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+
+      context 'when the cell displays "2021-06-01 00:00:01"' do
+        let(:gs_date_value) { 44_348.00001157 }
+        let(:formatted_cell_value) { '2021-06-01 00:00:01' }
+        it 'should return the expected Date' do
+          expect(subject).to be_kind_of(Date)
+          expect(subject.to_time).to be_within(tolerance).of(expected_value.to_time)
+        end
+      end
+    end
+  end
+end

--- a/spec/sheets_v4_spec.rb
+++ b/spec/sheets_v4_spec.rb
@@ -117,4 +117,124 @@ RSpec.describe SheetsV4 do
       expect { described_class.color(:non_existant_color) }.to raise_error(RuntimeError)
     end
   end
+
+  describe '.default_spreadsheet_tz' do
+    subject { described_class.default_spreadsheet_tz }
+    context 'when a default is not set' do
+      it 'shoud raise a RuntimeError' do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+
+    context 'when the default is set' do
+      before do
+        described_class.default_spreadsheet_tz = 'America/Los_Angeles'
+      end
+      it { is_expected.to eq('America/Los_Angeles') }
+    end
+  end
+
+  describe '.default_spreadsheet_tz=' do
+    subject { described_class.default_spreadsheet_tz = value }
+    context 'when value is a valid time zone' do
+      let(:value) { 'America/Los_Angeles' }
+      it 'should set the default time zone' do
+        subject
+        expect(described_class.default_spreadsheet_tz).to eq(value)
+      end
+    end
+    context 'when value is not a valid time zone' do
+      let(:value) { 'invalid time zone' }
+      it 'should raise a RuntimeError' do
+        expect { subject }.to raise_error(RuntimeError)
+      end
+    end
+  end
+
+  describe '.default_date_and_time_converter' do
+    subject { described_class.default_date_and_time_converter }
+    let(:default_spreadsheet_tz) { double('default_spreadsheet_tz') }
+    let(:converter) { double('converter') }
+
+    before do
+      allow(SheetsV4).to receive(:default_spreadsheet_tz).and_return(default_spreadsheet_tz)
+      allow(SheetsV4::ConvertDatesAndTimes).to(
+        receive(:new)
+        .with(default_spreadsheet_tz)
+        .and_return(converter)
+      )
+    end
+
+    after do
+      SheetsV4.instance_variable_set(:@default_date_and_time_converter, nil)
+    end
+
+    it 'should create a new SheetsV4::ConvertDatesAndTimes' do
+      expect(subject).to eq(converter)
+    end
+  end
+
+  describe '.date_to_gs' do
+    subject { described_class.date_to_gs(date) }
+    let(:date) { double('date') }
+    let(:expected_result) { double('expected_result') }
+    let(:converter) { double('converter') }
+
+    before do
+      allow(SheetsV4).to(receive(:default_date_and_time_converter).and_return(converter))
+      allow(converter).to receive(:date_to_gs).with(date).and_return(expected_result)
+    end
+
+    it 'should call SheetsV4::ConvertDatesAndTimes#date_to_gs' do
+      expect(subject).to eq(expected_result)
+    end
+  end
+
+  describe '.gs_to_date' do
+    subject { described_class.gs_to_date(gs_date) }
+    let(:gs_date) { double('gs_date') }
+    let(:expected_result) { double('expected_result') }
+    let(:converter) { double('converter') }
+
+    before do
+      allow(SheetsV4).to(receive(:default_date_and_time_converter).and_return(converter))
+      allow(converter).to receive(:gs_to_date).with(gs_date).and_return(expected_result)
+    end
+
+    it 'should call SheetsV4::ConvertDatesAndTimes#gs_to_date' do
+      expect(subject).to eq(expected_result)
+    end
+  end
+
+  describe '.datetime_to_gs' do
+    subject { described_class.datetime_to_gs(datetime) }
+    let(:datetime) { double('datetime') }
+    let(:expected_result) { double('expected_result') }
+    let(:converter) { double('converter') }
+
+    before do
+      allow(SheetsV4).to(receive(:default_date_and_time_converter).and_return(converter))
+      allow(converter).to receive(:datetime_to_gs).with(datetime).and_return(expected_result)
+    end
+
+    it 'should call SheetsV4::ConvertDatesAndTimes#datetime_to_gs' do
+      expect(subject).to eq(expected_result)
+    end
+  end
+
+  describe '.gs_to_datetime' do
+    subject { described_class.gs_to_datetime(gs_datetime) }
+    let(:gs_datetime) { double('gs_datetime') }
+    let(:expected_result) { double('expected_result') }
+    let(:converter) { double('converter') }
+
+    before do
+      allow(SheetsV4).to(receive(:default_date_and_time_converter).and_return(converter))
+      allow(converter).to receive(:gs_to_datetime).with(gs_datetime).and_return(expected_result)
+    end
+
+    it 'should call SheetsV4::ConvertDatesAndTimes#gs_to_datetime' do
+      expect(subject).to eq(expected_result)
+    end
+  end
 end


### PR DESCRIPTION
Add methods to convert between spreadsheet date/time values (stored as numeric values) and Date & DateTime objects.

The following methods:
* `date_to_gs(date)`
* `datetime_to_gs(date_time)`
* `gs_to_date(cell_value)`
* `gs_to_datetime(cell_value)`

are added as class methods to `SheetsV4` and as instance methods to `ConvertDatesAndTimes`.

Spreadsheet timezone is respected and maintained via `SheetsV4::default_spreadsheet_tz` and `ConvertDatesAndTimes.new(time_zone)`.