### PR TITLE
Show the cop names on Rubocop offenses when Rubocop is run from Rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,6 +50,9 @@ require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new do |t|
   t.options = %w[
+    --display-cop-names
+    --display-style-guide
+    --extra-details
     --format progress
     --format json --out rubocop-report.json
   ]


### PR DESCRIPTION
Rubocop's rake configuration is separate from the configuration .rubocop.yml. 

Add the `--display-cop-names` in the Rakefile so that cop names are shown for offenses reported when running Rubocop with Rake.