### PR TITLE
Auto correct Rubocop Gemspec/AddRuntimeDependency offenses

### DIFF
--- a/sheets_v4.gemspec
+++ b/sheets_v4.gemspec
@@ -48,10 +48,10 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'yardstick', '~> 0.9'
   end
 
-  spec.add_runtime_dependency 'activesupport', '~> 7.0'
+  spec.add_dependency 'activesupport', '~> 7.0'
   spec.add_development_dependency 'github_pages_rake_tasks', '~> 0.1'
-  spec.add_runtime_dependency 'google-apis-sheets_v4', '~> 0.26'
-  spec.add_runtime_dependency 'googleauth'
-  spec.add_runtime_dependency 'json_schemer', '~> 2.0'
-  spec.add_runtime_dependency 'rltk', '~> 3.0'
+  spec.add_dependency 'google-apis-sheets_v4', '~> 0.26'
+  spec.add_dependency 'googleauth'
+  spec.add_dependency 'json_schemer', '~> 2.0'
+  spec.add_dependency 'rltk', '~> 3.0'
 end


### PR DESCRIPTION
This pull request fixes offenses in the Gemspec file related to the Rubocop linter. 
