### PR TITLE
Standardize YARD and Markdown Lint configurations

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -9,7 +9,7 @@ MD013: { line_length: 90, tables: false, code_blocks: false }
 # Heading duplication is allowed for non-sibling headings
 MD024: { siblings_only: true }
 
-# Do not allow the specified trailig punctuation in a header
+# Do not allow the specified trailing punctuation in a header
 MD026: { punctuation: '.,;:' }
 
 # Order list items must have a prefix that increases in numerical order

--- a/.yardopts
+++ b/.yardopts
@@ -2,5 +2,8 @@
 --hide-void-return
 --markup-provider=redcarpet
 --markup markdown
+--exclude examples/**
 - CHANGELOG.md
+- CONTRIBUTING.md
+- RELEASING.md
 - LICENSE.txt


### PR DESCRIPTION
Add standard `.yardopts` file and `.markdownlint.yml` file to this project so that all `main-branch` projects have the same configuration for editing and generating YARD and other Markdown documentation.