### PR TITLE
Use shared Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,37 +1,7 @@
+inherit_gem:
+  main_branch_shared_rubocop_config: config/rubocop.yml
+
 AllCops:
-  NewCops: enable
-  # Output extra information for each offense to make it easier to diagnose:
-  DisplayCopNames: true
-  DisplayStyleGuide: true
-  ExtraDetails: true
-  SuggestExtensions: false
-  # RuboCop enforces rules depending on the oldest version of Ruby which
-  # your project supports:
+  # Pin this project to Ruby 3.1 in case the shared config above is upgraded to 3.2
+  # or later.
   TargetRubyVersion: 3.1
-
-Gemspec/DevelopmentDependencies:
-  EnforcedStyle: gemspec
-
-# The default max line length is 80 characters
-Layout/LineLength:
-  Max: 120
-
-# The DSL for RSpec and the gemspec file make it very hard to limit block length:
-Metrics/BlockLength:
-  Exclude:
-    - "spec/spec_helper.rb"
-    - "spec/**/*_spec.rb"
-    - "*.gemspec"
-
-Metrics/ModuleLength:
-  CountAsOne: ['hash']
-
-# When writing minitest tests, it is very hard to limit test class length:
-Metrics/ClassLength:
-  CountAsOne: ['hash']
-  Exclude:
-    - "test/**/*_test.rb"
-
-Style/AsciiComments:
-  Enabled: false
-

--- a/Rakefile
+++ b/Rakefile
@@ -48,17 +48,9 @@ CLEAN << 'rspec-report.xml'
 
 require 'rubocop/rake_task'
 
-RuboCop::RakeTask.new do |t|
-  t.options = %w[
-    --display-cop-names
-    --display-style-guide
-    --extra-details
-    --format progress
-    --format json --out rubocop-report.json
-  ]
-end
+RuboCop::RakeTask.new
 
-CLEAN << 'rubocop-report.json'
+# YARD
 
 unless RUBY_PLATFORM == 'java'
   # yard:build

--- a/sheets_v4.gemspec
+++ b/sheets_v4.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler-audit', '~> 0.9'
   spec.add_development_dependency 'create_github_release', '~> 1.5'
   spec.add_development_dependency 'discovery_v1', '~> 0.1'
+  spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.66'


### PR DESCRIPTION
Update the .rubocop.yml to inherit from a shared Rubocop config from the main_branch_shared_rubocop_config gem.