### PR TITLE
Adjust CI workflows for main branch merges and releases

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,9 +1,6 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [main]
-
   pull_request:
     branches: [main]
 
@@ -22,6 +19,10 @@ jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
 
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
 
@@ -34,19 +35,6 @@ jobs:
         ruby: ["3.1", "3.4"]
         operating-system: [ubuntu-latest]
         fail_on_low_coverage: ["true"]
-        include:
-          - ruby: "jruby-9.4"
-            operating-system: ubuntu-latest
-            fail_on_low_coverage: "false"
-          - ruby: "truffleruby-24"
-            operating-system: ubuntu-latest
-            fail_on_low_coverage: "false"
-          - ruby: "3.1"
-            operating-system: windows-latest
-            fail_on_low_coverage: "false"
-          - ruby: "jruby-9.4"
-            operating-system: windows-latest
-            fail_on_low_coverage: "false"
 
     steps:
       - name: Checkout

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -9,6 +9,10 @@ jobs:
   commit-lint:
     name: Verify Conventional Commits
 
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -1,9 +1,6 @@
 name: Experimental Ruby Builds
 
 on:
-  push:
-    branches: [main]
-
   workflow_dispatch:
 
 env:
@@ -29,8 +26,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - ruby: "3.1"
+            operating-system: windows-latest
+            fail_on_low_coverage: "false"
           - ruby: head
             operating-system: ubuntu-latest
+            fail_on_low_coverage: "false"
+          - ruby: "truffleruby-24"
+            operating-system: ubuntu-latest
+            fail_on_low_coverage: "false"
+          - ruby: "jruby-9.4"
+            operating-system: ubuntu-latest
+            fail_on_low_coverage: "false"
+          - ruby: "jruby-9.4"
+            operating-system: windows-latest
             fail_on_low_coverage: "false"
 
     steps:


### PR DESCRIPTION
Prevent CI builds from triggering on merges to the main branch and for release pull requests. Ensure workflows are only activated for pull requests targeting main and allow manual triggering for experimental builds.