### PR TITLE
build(dependencies): update dependencies for the GitHub Actions workflows

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with: { fetch-depth: 0 }
 
       - name: Check Commit Messages

--- a/.github/workflows/experimental_ruby_builds.yml
+++ b/.github/workflows/experimental_ruby_builds.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
 
     steps:
       - name: Checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}

--- a/lib/sheets_v4/google_extensions.rb
+++ b/lib/sheets_v4/google_extensions.rb
@@ -19,7 +19,8 @@ require_relative 'google_extensions/spreadsheet'
 require_relative 'google_extensions/sheet'
 
 # @private
-module Google
+
+module Google # rubocop:disable Style/OneClassPerFile
   module Apis
     # Add SheetsV4 extensions to Google::Apis::SheetsV4 classes
     module SheetsV4


### PR DESCRIPTION
Update GitHub Actions workflow dependencies to their latest major versions.

## Changes

- `actions/checkout`: `@v4` → `@v6` (latest: v6.0.2)
- `googleapis/release-please-action`: `@v4` → `@v5` (latest: v5.0.0)

## No changes needed

- `ruby/setup-ruby@v1` — latest is still v1 (latest: v1.305.0)
- `rubygems/release-gem@v1` — latest is still v1 (latest: v1.2.0)
- `wagoid/commitlint-github-action@v6` — latest is still v6 (latest: v6.2.1)